### PR TITLE
Set Field Reference only when it is None

### DIFF
--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -67,6 +67,10 @@ class Field:
     rows: list[Row] = field(default_factory=list)
 
     @property
+    def reference(self) -> list:
+        return [self.reference_lat, self.reference_lon]
+
+    @property
     def outline(self) -> list[Point]:
         if len(self.outline_wgs84) > 0:
             cartesian_outline = []
@@ -128,6 +132,12 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.active_object = None
         self.OBJECT_SELECTED.emit()
         self.invalidate()
+
+    def set_reference(self, field: Field, point: list) -> None:
+        if field.reference_lat is None:
+            point[0]
+        if field.reference_lon is None:
+            point[1]
 
     def add_obstacle(self, field: Field, obstacle: FieldObstacle) -> None:
         field.obstacles.append(obstacle)

--- a/field_friend/interface/field_planner.py
+++ b/field_friend/interface/field_planner.py
@@ -206,10 +206,10 @@ class field_planner:
                     with ui.column().style("display: block; overflow: auto; width: 100%"):
                         if self.coordinate_type == "cartesian":
                             points = self.field_provider.active_object['object'].points(
-                                [self.field_provider.active_field.reference_lat, self.field_provider.active_field.reference_lon])
+                                self.field_provider.active_field.reference)
                             for point in points:
                                 with ui.row().style("width: 100%;"):
-                                    ui.button(on_click=lambda point=point: self.leafet_map.m.set_center(self.field_provider.active_object['object'].points_wgs84[self.field_provider.active_object['object'].points([self.field_provider.active_field.reference_lat, self.field_provider.active_field.reference_lon]).index(point)])).props(
+                                    ui.button(on_click=lambda point=point: self.leafet_map.m.set_center(self.field_provider.active_object['object'].points_wgs84[self.field_provider.active_object['object'].points(self.field_provider.active_field.reference).index(point)])).props(
                                         'icon=place color=primary fab-mini flat').tooltip('center map on point').classes('ml-0')
                                     ui.label(f'x: {float("{:.2f}".format(point.x))}')
                                     ui.label(f'y: {float("{:.2f}".format(point.y))}')
@@ -249,10 +249,10 @@ class field_planner:
                     with ui.column().style("display: block; overflow: auto; width: 100%"):
                         if self.coordinate_type == "cartesian":
                             points = self.field_provider.active_object['object'].points(
-                                [self.field_provider.active_field.reference_lat, self.field_provider.active_field.reference_lon])
+                                self.field_provider.active_field.reference)
                             for point in points:
                                 with ui.row().style("width: 100%;"):
-                                    ui.button(on_click=lambda point=point: self.leafet_map.m.set_center(self.field_provider.active_object['object'].points_wgs84[self.field_provider.active_object['object'].points([self.field_provider.active_field.reference_lat, self.field_provider.active_field.reference_lon]).index(point)])).props(
+                                    ui.button(on_click=lambda point=point: self.leafet_map.m.set_center(self.field_provider.active_object['object'].points_wgs84[self.field_provider.active_object['object'].points(self.field_provider.active_field.reference).index(point)])).props(
                                         'icon=place color=primary fab-mini flat').tooltip('center map on point').classes('ml-0')
                                     ui.label(f'x: {float("{:.2f}".format(point.x))}')
                                     ui.label(f'y: {float("{:.2f}".format(point.y))}')
@@ -321,8 +321,7 @@ class field_planner:
                 return
             new_point = positioning
             if len(self.field_provider.active_field.outline_wgs84) < 1:
-                self.field_provider.active_field.reference_lat = new_point[0]
-                self.field_provider.active_field.reference_lon = new_point[1]
+                self.field_provider.set_reference(self.field_provider.active_field, new_point)
                 self.gnss.set_reference(lat=new_point[0], lon=new_point[1])
             field.outline_wgs84.append(new_point)
         self.field_provider.invalidate()


### PR DESCRIPTION
1. Possibly, all points of a field could be deleted by the user. When a new point is then added to the empty list, this point will be the new reference point of the field. We want to prevent the system from doing this because the field's rows and its crops are depending on this reference point. 
2. the reference of the field can now be accessed by symply requesting `field.reference`. This will return the reference lat and lon as a list, e.g. `[52.0000,7.0000]`.