### PR TITLE
Ensure we have a float; not non-serializable decimal for gnss heading

### DIFF
--- a/field_friend/navigation/gnss.py
+++ b/field_friend/navigation/gnss.py
@@ -196,7 +196,7 @@ class GnssHardware(Gnss):
                         # print(f'The GNSS message: {msg.mode_indicator}')
                         has_location = True
                     if msg.sentence_type == 'HDT' and getattr(msg, 'heading', None):
-                        record.heading = msg.heading
+                        record.heading = float(msg.heading)
                         has_heading = True
                 except pynmea2.ParseError as e:
                     self.log.info(f'Parse error: {e}')
@@ -221,7 +221,7 @@ class GnssHardware(Gnss):
                     cartesian_coordinates = wgs84_to_cartesian([self.reference_lat, self.reference_lon], [
                         record.latitude, record.longitude])
                     if has_heading:
-                        yaw = np.deg2rad(float(-record.heading))
+                        yaw = np.deg2rad(-record.heading)
                     else:
                         yaw = self.odometer.get_pose(time=record.timestamp).yaw
                         # TODO: Better INS implementation if no heading provided by GNSS


### PR DESCRIPTION
This pull request ensures we work with a heading value which is always of type `float`, not `Decimal`. Before, backup of gnss failed:

```
rosys_1       | 2024-05-02 07:21:44.142 [ERROR] nicegui/app/app.py:118: Object of type Decimal is not JSON serializable
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/nicegui/background_tasks.py", line 52, in _handle_task_result
rosys_1       |     task.result()
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/nicegui/client.py", line 290, in result_with_client
rosys_1       |     await result
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/rosys.py", line 225, in shutdown
rosys_1       |     await persistence.backup(force=True)
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 43, in inner
rosys_1       |     return await io_bound(func, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 31, in io_bound
rosys_1       |     return await loop.run_in_executor(thread_pool, partial(callback, *args, **kwargs))
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
rosys_1       |     result = self.fn(*self.args, **self.kwargs)
rosys_1       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 42, in backup
rosys_1       |     filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
rosys_1       |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/__init__.py", line 238, in dumps
rosys_1       |     **kw).encode(obj)
rosys_1       |           ^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 202, in encode
rosys_1       |     chunks = list(chunks)
rosys_1       |              ^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 432, in _iterencode
rosys_1       |     yield from _iterencode_dict(o, _current_indent_level)
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
rosys_1       |     yield from chunks
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
rosys_1       |     yield from chunks
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 439, in _iterencode
rosys_1       |     o = _default(o)
rosys_1       |         ^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 31, in default
rosys_1       |     return json.JSONEncoder.default(self, o)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 180, in default
rosys_1       |     raise TypeError(f'Object of type {o.__class__.__name__} '
rosys_1       | TypeError: Object of type Decimal is not JSON serializable
```