### PR TITLE
Remove non-functional restart via keyboard shortcut

### DIFF
--- a/field_friend/interface/components/key_controls.py
+++ b/field_friend/interface/components/key_controls.py
@@ -27,9 +27,6 @@ class KeyControls(rosys.driving.keyboard_control):
             if e.key == '!':
                 self.automator.start(self.puncher.try_home())
 
-        if e.action.keydown and e.key == 'r' and e.modifiers.shift:
-            self.system.restart()
-
         if e.action.keydown and e.key == 's':
             if self.automator.is_running:
                 self.automator.stop(because='stop button was pressed')


### PR DESCRIPTION
This PR removes the keyboard shortcut to restart the system. In the current form it does not work (because SHIFT always leads to an capital `R`) and in general this should be not be triggered by accident.