### PR TITLE
Fix random shutdowns produced by GNSS signal data

### DIFF
--- a/field_friend/navigation/gnss.py
+++ b/field_friend/navigation/gnss.py
@@ -171,7 +171,7 @@ class GnssHardware(Gnss):
                     self.log.debug('No data received')
                     return
                 try:
-                    msg = await rosys.run.cpu_bound(pynmea2.parse, line)
+                    msg = pynmea2.parse(line)
                     if not hasattr(msg, 'sentence_type'):
                         self.log.debug(f'No sentence type: {msg}')
                         return
@@ -206,10 +206,10 @@ class GnssHardware(Gnss):
             self.device = None
             return
         if self.record.gps_qual > 0 and record.gps_qual == 0:
-            self.log.info('GNSS lost')
+            self.log.warning('GNSS lost')
             self.GNSS_CONNECTION_LOST.emit()
         if self.record.gps_qual == 4 and record.gps_qual != 4:
-            self.log.info('GNSS RTK fix lost')
+            self.log.warning('GNSS RTK fix lost')
             self.RTK_FIX_LOST.emit()
         self.record = deepcopy(record)
         if has_location:


### PR DESCRIPTION
Somehow wrapping pynmea2.parse in  run.cpu_bound produced random rosys shutdowns. While the underlying core issue is still not understood, removing the cpu_bound wrapping makes the random shutdowns disappear.