### PR TITLE
Fix errors in coordinate transformation and field creation

### DIFF
--- a/field_friend/interface/components/leaflet_map.py
+++ b/field_friend/interface/components/leaflet_map.py
@@ -8,6 +8,8 @@ import rosys.geometry
 from nicegui import app, events, ui
 from nicegui.elements.leaflet_layers import TileLayer
 
+from field_friend.automations.field_provider import Field
+
 from .key_controls import KeyControls
 
 if TYPE_CHECKING:

--- a/field_friend/navigation/point_transformation.py
+++ b/field_friend/navigation/point_transformation.py
@@ -1,24 +1,20 @@
-from typing import List
-
 import numpy as np
 from geographiclib.geodesic import Geodesic
 
 
-def wgs84_to_cartesian(reference, point) -> List[float]:
+def wgs84_to_cartesian(reference, point) -> list[float]:
     r = Geodesic.WGS84.Inverse(reference[0], reference[1], point[0], point[1])
     s = r['s12']
-    a = -np.deg2rad(r['azi1'])
-    x = s * np.cos(a)
-    y = s * np.sin(a)
-    cartesian_coords = [x, y]
-    return cartesian_coords
+    a = np.deg2rad(r['azi1'])
+    x = s * np.sin(a)
+    y = s * np.cos(a)
+    return [x, y]
 
 
-def cartesian_to_wgs84(reference, point) -> List[float]:
+def cartesian_to_wgs84(reference, point) -> list[float]:
     r = Geodesic.WGS84.Direct(reference[0], reference[1], 90.0, point[0])
     r = Geodesic.WGS84.Direct(r['lat2'], r['lon2'], 0.0, point[1])
-    wgs84_coords = [r['lat2'], r['lon2']]
-    return wgs84_coords
+    return [r['lat2'], r['lon2']]
 
 
 def get_new_position(reference, distance, yaw):


### PR DESCRIPTION
This pull request fixes the coordinate transformation from WGS84 to cartesian coordinates. The error can be reproduced on `main` branch like this:

- open the field planner
- create a new field with the leaflet polygon editor
- switch to main page
- start mowing automation

Expected: the robot drives inside the drawn polygon on the map.
Actual: the robot drives the same shape but somehow mirrored/ofsetted from the polygon on the map.