### PR TITLE
Persist current automation via RoSys, not app.user

### DIFF
--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -63,8 +63,7 @@ class operation:
                         self.automations_toggle = ui.select([key for key in self.system.automations.keys()],
                                                             on_change=self.handle_automation_changed) \
                             .classes('w-full border pl-2').style('border: 2px solid #6E93D6; border-radius: 5px; background-color: #EEF4FA')
-                        self.automations_toggle.value = {v: k for k, v in self.system.automations.items()} \
-                            .get(self.system.automator.default_automation, None)
+                        self.automations_toggle.value = self.system.get_current_automation_id()
                     with ui.column().bind_visibility_from(self.automations_toggle, 'value', value='mowing'):
                         with ui.row():
                             ui.number('Padding', value=0.5, step=0.1, min=0.0, format='%.1f') \

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -63,7 +63,8 @@ class operation:
                         self.automations_toggle = ui.select([key for key in self.system.automations.keys()],
                                                             on_change=self.handle_automation_changed) \
                             .classes('w-full border pl-2').style('border: 2px solid #6E93D6; border-radius: 5px; background-color: #EEF4FA')
-                        self.automations_toggle.value = app.storage.user.get('automation', 'weeding')
+                        self.automations_toggle.value = {v: k for k, v in self.system.automations.items()} \
+                            .get(self.system.automator.default_automation, None)
                     with ui.column().bind_visibility_from(self.automations_toggle, 'value', value='mowing'):
                         with ui.row():
                             ui.number('Padding', value=0.5, step=0.1, min=0.0, format='%.1f') \
@@ -299,5 +300,5 @@ class operation:
         return True
 
     def handle_automation_changed(self, e: events.ValueChangeEventArguments) -> None:
-        app.storage.user.update({'automation': e.value})
         self.system.automator.default_automation = self.system.automations[e.value]
+        self.system.request_backup()

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -139,14 +139,14 @@ class System(rosys.persistence.PersistentModule):
         os.utime('main.py')
 
     def backup(self) -> dict:
-        automation = self.automator.default_automation
-        if automation is None:
-            automation_id = None
-        else:
-            automation_id = {v: k for k, v in self.automations.items()}.get(automation, None)
-        return {'automation': automation_id}
+        return {'automation': self.get_current_automation_id()}
 
     def restore(self, data: dict[str, Any]) -> None:
         name = data.get('automation', None)
         automation = self.automations.get(name, None)
         self.automator.default_automation = automation
+
+    def get_current_automation_id(self) -> str | None:
+        if self.automator.default_automation is None:
+            return None
+        return {v: k for k, v in self.automations.items()}.get(self.automator.default_automation, None)

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Any
 
 import numpy as np
 import rosys
@@ -14,8 +15,10 @@ from .interface.components.info import Info
 from .kpi_generator import generate_kpis
 
 
-class System:
+class System(rosys.persistence.PersistentModule):
+
     def __init__(self) -> None:
+        super().__init__()
         rosys.hardware.SerialCommunication.search_paths.insert(0, '/dev/ttyTHS0')
         self.log = logging.getLogger('field_friend.system')
         self.is_real = rosys.hardware.SerialCommunication.is_possible()
@@ -134,3 +137,16 @@ class System:
 
     def restart(self) -> None:
         os.utime('main.py')
+
+    def backup(self) -> dict:
+        automation = self.automator.default_automation
+        if automation is None:
+            automation_id = None
+        else:
+            automation_id = {v: k for k, v in self.automations.items()}.get(automation, None)
+        return {'automation': automation_id}
+
+    def restore(self, data: dict[str, Any]) -> None:
+        name = data.get('automation', None)
+        automation = self.automations.get(name, None)
+        self.automator.default_automation = automation


### PR DESCRIPTION
This PR fixes persistence by using RoSys instead of a per-user storage (which then may change the currently selected automation in the system).