### PR TITLE
Use .env to specify robot id / version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - /run/udev:/run/udev:ro # to get the device identifiers
       - /etc/hostname:/mnt/host_hostname:ro #to get the hostname into the docker
     environment:
-      - ROBOT_ID=Field Friend
       - TZ=Europe/Amsterdam
     hostname: docker
     cap_add:

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -50,10 +50,12 @@ from .kpi_generator import generate_kpis
 
 class System(rosys.persistence.PersistentModule):
 
-    version = 'rb28'  # insert here your field friend version to be simulated
+    version = 'unknown'  # This is set in main.py through the environment variable VERSION or ROBOT_ID
 
     def __init__(self) -> None:
         super().__init__()
+        assert self.version is not None
+        assert self.version != 'unknown'
         rosys.hardware.SerialCommunication.search_paths.insert(0, '/dev/ttyTHS0')
         self.log = logging.getLogger('field_friend.system')
         self.is_real = rosys.hardware.SerialCommunication.is_possible()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-import rosys
+import os
+
+from dotenv import load_dotenv
 from nicegui import app, ui
 from rosys.analysis import logging_page
 
@@ -12,7 +14,18 @@ logger = log_configuration.configure()
 app.add_static_files('/assets', 'assets')
 
 
+load_dotenv('.env')
+
+
 def startup() -> None:
+    robot_id = os.environ.get('ROBOT_ID')
+    if robot_id is None:
+        msg = 'The ROBOT_ID environment variable is not set. Please set it in the .env file.'
+        logger.warning(msg)
+        ui.label(msg).classes('text-xl')
+        return
+    logger.info(f'Starting Field Friend for robot {robot_id}')
+    System.version = os.environ.get('VERSION') or robot_id
     system = System()
 
     def page_wrapper() -> None:
@@ -37,10 +50,12 @@ def startup() -> None:
 
 app.on_startup(startup)
 
-ui.run(title='Field Friend',
-       port=80,
-       storage_secret='feldfreund',
-       favicon='assets/favicon.ico',
-       binding_refresh_interval=0.3,
-       reconnect_timeout=10,
-       )
+ui.run(
+    title='Field Friend',
+    port=int(os.environ.get('PORT', '80')),
+    storage_secret='feldfreund',
+    favicon='assets/favicon.ico',
+    binding_refresh_interval=0.3,
+    reconnect_timeout=10,
+    on_air=os.environ.get('ON_AIR_TOKEN'),
+)


### PR DESCRIPTION
This pull request reads the ROBOT_ID from the .env file instead of the hard coded variable it was before. Normally the ROBOT_ID should be really the robot (eg. F13, U6, ...) and not the Robot Brain serial number. Because config parsing currently is based on that, a VERSION can also be defined which is then used by System.

NOTE: This branch is based on https://github.com/zauberzeug/field_friend/pull/75.