### PR TITLE
Add checkbox to disable spacing-related crop prediction

### DIFF
--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -92,19 +92,19 @@ class Tornado(WeedingImplement):
     def settings_ui(self):
         super().settings_ui()
 
-        ui.number('Tornado angle', format='%.0f', value=180, step=1, min=0, max=180) \
+        ui.number('Tornado angle', format='%.0f', step=1, min=0, max=180) \
             .props('dense outlined suffix=°') \
             .classes('w-24') \
             .bind_value(self, 'tornado_angle') \
             .tooltip('Set the angle for the tornado drill')
         ui.label().bind_text_from(self, 'tornado_angle', lambda v: f'Tornado diameters: {self.field_friend.tornado_diameters(v)[0]*100:.1f} cm '
                                   f'- {self.field_friend.tornado_diameters(v)[1]*100:.1f} cm')
-        ui.checkbox('With punch check', value=True) \
+        ui.checkbox('With punch check') \
             .bind_value(self, 'with_punch_check') \
             .tooltip('Set the weeding automation to check for punch')
-        ui.checkbox('Drill 2x with open torando', value=False,) \
+        ui.checkbox('Drill 2x with open torando') \
             .bind_value(self, 'drill_with_open_tornado') \
             .tooltip('Set the weeding automation to drill a second time with open tornado')
-        ui.checkbox('Drill between crops', value=False) \
+        ui.checkbox('Drill between crops') \
             .bind_value(self, 'drill_between_crops') \
             .tooltip('Set the weeding automation to drill between crops')

--- a/field_friend/automations/implements/weeding_screw.py
+++ b/field_friend/automations/implements/weeding_screw.py
@@ -70,13 +70,13 @@ class WeedingScrew(WeedingImplement):
 
     def settings_ui(self):
         super().settings_ui()
-        ui.number('Drill depth', value=0.02, format='%.2f', step=0.01,
+        ui.number('Drill depth', format='%.2f', step=0.01,
                   min=self.system.field_friend.z_axis.max_position, max=self.system.field_friend.z_axis.min_position*-1) \
             .props('dense outlined suffix=°') \
             .classes('w-24') \
             .bind_value(self, 'weed_screw_depth') \
             .tooltip('Set the drill depth for the weeding automation')
-        ui.number('Crop safety distance', value=0.01, step=0.001, min=0.001, max=0.05, format='%.3f') \
+        ui.number('Crop safety distance', step=0.001, min=0.001, max=0.05, format='%.3f') \
             .props('dense outlined suffix=m') \
             .classes('w-24') \
             .bind_value(self, 'crop_safety_distance') \

--- a/field_friend/automations/plant_provider.py
+++ b/field_friend/automations/plant_provider.py
@@ -20,22 +20,16 @@ def check_if_plant_exists(plant: Plant, plants: list[Plant], distance: float) ->
 
 
 class PlantProvider(rosys.persistence.PersistentModule):
-    def __init__(self,
-                 match_distance: float = 0.07,
-                 crop_spacing: float = 0.18,
-                 predict_crop_position: bool = True,
-                 prediction_confidence: float = 0.3,
-                 persistence_key: str = 'plant_provider',
-                 ) -> None:
+    def __init__(self, persistence_key: str = 'plant_provider') -> None:
         super().__init__(persistence_key=f'field_friend.automations.{persistence_key}')
         self.log = logging.getLogger('field_friend.plant_provider')
         self.weeds: list[Plant] = []
         self.crops: list[Plant] = []
 
-        self.match_distance = match_distance
-        self.crop_spacing = crop_spacing
-        self.predict_crop_position = predict_crop_position
-        self.prediction_confidence = prediction_confidence
+        self.match_distance: float = 0.07
+        self.crop_spacing: float = 0.18
+        self.predict_crop_position: bool = True
+        self.prediction_confidence: float = 0.3
         self.crop_confidence_threshold: float = 0.8
         self.weed_confidence_threshold: float = 0.8
 
@@ -141,31 +135,31 @@ class PlantProvider(rosys.persistence.PersistentModule):
         return [w for w in self.weeds if w.position.distance(point) <= max_distance and len(w.positions) >= 3 and w.confidence > self.weed_confidence_threshold]
 
     def settings_ui(self) -> None:
-        ui.number('Combined crop confidence threshold', value=0.8, step=0.05, min=0.05, max=5.00, format='%.2f') \
+        ui.number('Combined crop confidence threshold', step=0.05, min=0.05, max=5.00, format='%.2f') \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'crop_confidence_threshold') \
             .tooltip('Needed crop confidence for punshing')
-        ui.number('Combined weed confidence threshold', value=0.8, step=0.05, min=0.05, max=5.00, format='%.2f') \
+        ui.number('Combined weed confidence threshold', step=0.05, min=0.05, max=5.00, format='%.2f') \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'weed_confidence_threshold') \
             .tooltip('Needed weed confidence for punshing')
-        ui.number('Crop match distance', value=0.07, step=0.01, min=0.01, max=0.10, format='%.2f') \
+        ui.number('Crop match distance', step=0.01, min=0.01, max=0.10, format='%.2f') \
             .props('dense outlined suffix=m') \
             .classes('w-24') \
             .bind_value(self, 'match_distance') \
             .tooltip('Maximum distance for a detection to be considered the same plant')
-        ui.number('Crop spacing', value=0.18, step=0.01, min=0.01, max=1.00, format='%.2f') \
+        ui.number('Crop spacing', step=0.01, min=0.01, max=1.00, format='%.2f') \
             .props('dense outlined suffix=m') \
             .classes('w-24') \
             .bind_value(self, 'crop_spacing') \
             .tooltip('Spacing between crops needed for crop position prediction')
-        ui.number('Crop prediction confidence', value=0.3, step=0.05, min=0.05, max=1.00, format='%.2f') \
+        ui.number('Crop prediction confidence', step=0.05, min=0.05, max=1.00, format='%.2f') \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'prediction_confidence') \
             .tooltip('Confidence of the crop prediction')
-        ui.checkbox('Crop Prediction', value=False) \
+        ui.checkbox('Crop Prediction') \
             .bind_value(self, 'predict_crop_position') \
             .tooltip('Provides a confidence boost for crop detections that match the expected crop spacing')

--- a/tests/test_plant_provider.py
+++ b/tests/test_plant_provider.py
@@ -33,28 +33,19 @@ def test_crop_prediction():
     plant_provider.predict_crop_position = False
     confidence = 0.4
 
-    plant = Plant(type='maize', detection_time=rosys.time())
-    plant.positions.append(rosys.geometry.Point(x=0, y=0))
-    plant.confidences.append(confidence)
-    plant_provider.add_crop(plant)
+    def add_crop(x):
+        plant = Plant(type='maize', detection_time=rosys.time())
+        plant.positions.append(rosys.geometry.Point(x=x, y=0))
+        plant.confidences.append(confidence)
+        plant_provider.add_crop(plant)
+    
+    add_crop(x=0)
     assert plant_provider.crops[0].confidence == confidence
-
-    plant = Plant(type='maize', detection_time=rosys.time())
-    plant.positions.append(rosys.geometry.Point(x=plant_provider.crop_spacing, y=0))
-    plant.confidences.append(confidence)
-    plant_provider.add_crop(plant)
+    add_crop(x=plant_provider.crop_spacing)
     assert plant_provider.crops[1].confidence == confidence
-
     plant_provider.predict_crop_position = True
-    plant = Plant(type='maize', detection_time=rosys.time())
-    plant.positions.append(rosys.geometry.Point(x=2 * plant_provider.crop_spacing, y=0))
-    plant.confidences.append(confidence)
-    plant_provider.add_crop(plant)
+    add_crop(x=2 * plant_provider.crop_spacing)
     assert plant_provider.crops[2].confidence == (confidence + plant_provider.prediction_confidence)
-
     plant_provider.predict_crop_position = False
-    plant = Plant(type='maize', detection_time=rosys.time())
-    plant.positions.append(rosys.geometry.Point(x=3 * plant_provider.crop_spacing, y=0))
-    plant.confidences.append(confidence)
-    plant_provider.add_crop(plant)
+    add_crop(x=3 * plant_provider.crop_spacing)
     assert plant_provider.crops[3].confidence == confidence

--- a/tests/test_plant_provider.py
+++ b/tests/test_plant_provider.py
@@ -26,3 +26,35 @@ def create_crop(x: float, y: float) -> Plant:
         plant.positions.append(rosys.geometry.Point(x=x, y=y))
         plant.confidences.append(0.9)
     return plant
+
+
+def test_crop_prediction():
+    plant_provider = PlantProvider()
+    plant_provider.predict_crop_position = False
+    confidence = 0.4
+
+    plant = Plant(type='maize', detection_time=rosys.time())
+    plant.positions.append(rosys.geometry.Point(x=0, y=0))
+    plant.confidences.append(confidence)
+    plant_provider.add_crop(plant)
+    assert plant_provider.crops[0].confidence == confidence
+
+    plant = Plant(type='maize', detection_time=rosys.time())
+    plant.positions.append(rosys.geometry.Point(x=plant_provider.crop_spacing, y=0))
+    plant.confidences.append(confidence)
+    plant_provider.add_crop(plant)
+    assert plant_provider.crops[1].confidence == confidence
+
+    plant_provider.predict_crop_position = True
+    plant = Plant(type='maize', detection_time=rosys.time())
+    plant.positions.append(rosys.geometry.Point(x=2 * plant_provider.crop_spacing, y=0))
+    plant.confidences.append(confidence)
+    plant_provider.add_crop(plant)
+    assert plant_provider.crops[2].confidence == (confidence + plant_provider.prediction_confidence)
+
+    plant_provider.predict_crop_position = False
+    plant = Plant(type='maize', detection_time=rosys.time())
+    plant.positions.append(rosys.geometry.Point(x=3 * plant_provider.crop_spacing, y=0))
+    plant.confidences.append(confidence)
+    plant_provider.add_crop(plant)
+    assert plant_provider.crops[3].confidence == confidence


### PR DESCRIPTION
The crop position prediction doesn't help on fields with unstructured/irregular crop positions. And probably is even detrimental to the crop positioning.
This PR just provides a checkbox to disable it.

ToDos

- [x] review
- [x] nunit test