### PR TITLE
Switch ui events from register to register_ui

### DIFF
--- a/field_friend/interface/components/field_object.py
+++ b/field_friend/interface/components/field_object.py
@@ -11,7 +11,7 @@ class field_object(Group):
 
         self.field_provider = field_provider
         self.update(active_field)
-        self.field_provider.FIELDS_CHANGED.register(lambda: self.update(active_field))
+        self.field_provider.FIELDS_CHANGED.register_ui(lambda: self.update(active_field))
 
     def create_fence(self, start, end):
         height = 0.12

--- a/field_friend/interface/components/field_planner.py
+++ b/field_friend/interface/components/field_planner.py
@@ -46,7 +46,7 @@ class field_planner:
                     self.show_field_table()
             self.show_field_settings()
             self.show_object_settings()
-            self.field_provider.FIELDS_CHANGED.register(self.refresh_ui)
+            self.field_provider.FIELDS_CHANGED.register_ui(self.refresh_ui)
 
     def set_tab(self, e: events.ValueChangeEventArguments) -> None:
         self.tab = e.value

--- a/field_friend/interface/components/header_bar.py
+++ b/field_friend/interface/components/header_bar.py
@@ -61,7 +61,7 @@ class header_bar:
                     self.drawer_icon = "chevron_right"
                 ui.button(on_click=handle_toggle).props(f'icon={self.drawer_icon} flat color=white')
             change_drawer_icon()
-            self.STATUS_DRAWER_TOGGLED.register(change_drawer_icon.refresh)
+            self.STATUS_DRAWER_TOGGLED.register_ui(change_drawer_icon.refresh)
 
     def _show_battery(self, robot: FieldFriend) -> ui.row:
         with ui.row().classes('items-center gap-1') as row:

--- a/field_friend/interface/components/leaflet_map.py
+++ b/field_friend/interface/components/leaflet_map.py
@@ -95,7 +95,7 @@ class leaflet_map:
 
         with self.m as m:
             m.on('draw:created', handle_draw)
-        self.gnss.ROBOT_GNSS_POSITION_CHANGED.register(self.update_robot_position)
+        self.gnss.ROBOT_GNSS_POSITION_CHANGED.register_ui(self.update_robot_position)
 
     def buttons(self) -> None:
         """Builds additional buttons to interact with the map."""

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -56,7 +56,7 @@ class operation:
                 .bind_value_from(self.system, 'current_implement', lambda i: i.name)
             self.implement_selection.value = self.system.current_implement.name
 
-        self.system.puncher.POSSIBLE_PUNCH.register(self.can_punch)
+        self.system.puncher.POSSIBLE_PUNCH.register_ui(self.can_punch)
         self.punch_dialog = PunchDialog(self.system.usb_camera_provider,
                                         self.system.plant_locator,
                                         self.system.odometer)


### PR DESCRIPTION
This PR fixes #89 with it's first commit.
The second commit switches all other ui related registers to register_ui.