### PR TITLE
Deactivate image upload of detector

### DIFF
--- a/docker-compose.jetson.orin.yml
+++ b/docker-compose.jetson.orin.yml
@@ -6,7 +6,7 @@ services:
     privileged: true
 
   detector:
-    image: "zauberzeug/yolov5-detector:nlv0.8.8-35.4.1"
+    image: "zauberzeug/yolov5-detector:nlv0.10.8-35.4.1"
     restart: always
     ports:
       - "8004:80"
@@ -34,7 +34,7 @@ services:
   #     - ~/data_coins:/data
 
   monitoring:
-    image: "zauberzeug/yolov5-detector:nlv0.8.8-35.4.1"
+    image: "zauberzeug/yolov5-detector:nlv0.10.8-35.4.1"
     restart: always
     ports:
       - "8005:80"

--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -138,21 +138,11 @@ class PlantLocator(rosys.persistence.PersistentModule):
         self.is_paused = False
 
     async def get_outbox_mode(self, port: int) -> bool:
-        url = f'http://localhost:{port}/outbox_mode'
-        async with aiohttp.ClientSession() as session:
-            try:
-                response = await session.get(url)
-            except aiohttp.client_exceptions.ClientConnectorError:
-                self.log.error(f'Could not connect to Detector on port {port}. Is it running?')
-                return False
-        response_text = await response.text()
-        return response_text == 'continous_upload'
+        return response_text == 'continuous_upload'
     
     async def set_outbox_mode(self, value: bool, port: int) -> bool:
         url = f'http://localhost:{port}/outbox_mode'
-        # continous_upload
-        # stopped
-        async with aiohttp.request('PUT', url, data='continous_upload' if value else 'stopped') as response:
+        async with aiohttp.request('PUT', url, data='continuous_upload' if value else 'stopped') as response:
             if response.status != 200:
                 return False
             return True

--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -148,14 +148,13 @@ class PlantLocator(rosys.persistence.PersistentModule):
             response_text = await response.text()
         return response_text == 'continuous_upload'
     
-    async def set_outbox_mode(self, value: bool, port: int) -> bool:
+    async def set_outbox_mode(self, value: bool, port: int) -> None:
         url = f'http://localhost:{port}/outbox_mode'
         async with aiohttp.request('PUT', url, data='continuous_upload' if value else 'stopped') as response:
             if response.status != 200:
                 self.log.error(f'Could not set outbox mode to {value} on port {port} - status code: {response.status}')
-                return False
+                return
             self.log.info(f'Outbox_mode was set to {value} on port {port}')
-            return True
 
     def settings_ui(self) -> None:
         ui.number('Min. weed confidence', format='%.2f', value=0.8, step=0.05, min=0.0, max=1.0, on_change=self.request_backup) \


### PR DESCRIPTION
A REST api to pause the upload of images to the learning loop was added to the detector node.
This PR adds a checkbox to call that api, but it still needs some work.
In the future we want it to automaticly upload when a wifi connection is detected and deactivate it when using a mobile connection.

- [x] Tested locally with dummy server
- [x] Test on robot