### PR TITLE
fix: Weeding Screw moves down when automation is stopped

### DIFF
--- a/.syncignore
+++ b/.syncignore
@@ -12,3 +12,4 @@ sync.sh
 nicegui
 rosys
 .nicegui
+.venv

--- a/field_friend/automations/implements/weeding_implement.py
+++ b/field_friend/automations/implements/weeding_implement.py
@@ -72,7 +72,7 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
         await self.system.field_friend.flashlight.turn_off()
         self.system.plant_locator.pause()
         self.kpi_provider.increment_weeding_kpi('rows_weeded')
-        await self.puncher.field_friend.z_axis.return_to_reference()
+        # await self.puncher.field_friend.z_axis.return_to_reference()
 
     async def observe(self) -> None:
         self.log.info('checking for plants...')

--- a/field_friend/automations/implements/weeding_implement.py
+++ b/field_friend/automations/implements/weeding_implement.py
@@ -72,7 +72,6 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
         await self.system.field_friend.flashlight.turn_off()
         self.system.plant_locator.pause()
         self.kpi_provider.increment_weeding_kpi('rows_weeded')
-        # await self.puncher.field_friend.z_axis.return_to_reference()
 
     async def observe(self) -> None:
         self.log.info('checking for plants...')


### PR DESCRIPTION
As described in #94 the weeding implement moves down when the automation is stopped.
We identified the [line](https://github.com/zauberzeug/field_friend/blob/140304cdbbbffb0ec8966a649316c890f60f3073/field_friend/automations/implements/weeding_implement.py#L75)