### PR TITLE
Do not show rosys debug logs

### DIFF
--- a/field_friend/log_configuration.py
+++ b/field_friend/log_configuration.py
@@ -89,7 +89,7 @@ def configure():
             },
             'rosys': {
                 'handlers': ['console', 'debugfile'],
-                'level': 'DEBUG',
+                'level': 'INFO',
                 'propagate': False,
             },
             project: {


### PR DESCRIPTION
Lately RoSys introduced more debug logging for the Axis camera system. Because it pollutes the whole Field Friend log, I suggest we disable debug logs for RoSys.

**ToDos**

- [ ] test on real robot