### PR TITLE
Add 'autoupload' to detector tags

### DIFF
--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -76,7 +76,7 @@ class PlantLocator(rosys.persistence.PersistentModule):
         if new_image is None or new_image.detections:
             await rosys.sleep(0.01)
             return
-        await self.detector.detect(new_image, autoupload=self.autoupload, tags=self.tags + [self.robot_name])
+        await self.detector.detect(new_image, autoupload=self.autoupload, tags=self.tags + [self.robot_name, 'autoupload'])
         if rosys.time() - t < 0.01:  # ensure maximum of 100 Hz
             await rosys.sleep(0.01 - (rosys.time() - t))
         if not new_image.detections:


### PR DESCRIPTION
As requested by @denniswittich this PR adds 'autoupload' to the tags send to the detector.
This was tested on U4/RB28.