### PR TITLE
Always keep crops safe

### DIFF
--- a/field_friend/automations/implements/weeding_screw.py
+++ b/field_friend/automations/implements/weeding_screw.py
@@ -23,7 +23,6 @@ class WeedingScrew(WeedingImplement):
     async def start_workflow(self) -> bool:
         await super().start_workflow()
         try:
-            self._keep_crops_safe()
             weeds_in_range = {weed_id: position for weed_id, position in self.weeds_to_handle.items()
                               if self.system.field_friend.can_reach(position)}
             if not weeds_in_range:
@@ -65,6 +64,7 @@ class WeedingScrew(WeedingImplement):
             raise ImplementException(f'Error while Weed Screw Workflow: {e}') from e
 
     def _has_plants_to_handle(self) -> bool:
+        self._keep_crops_safe()
         super()._has_plants_to_handle()
         return any(self.weeds_to_handle)
 


### PR DESCRIPTION
Currently the robot might overshoot a weed because they are not moved away from a crop while running the observation. This PR fixes this problem.

**ToDos**

- [ ] write a autmated test
- [ ] review