### PR TITLE
fixing closed-loop stepper motor alarm (for U4)

### DIFF
--- a/.github/workflows/milestone_check.yml
+++ b/.github/workflows/milestone_check.yml
@@ -1,0 +1,17 @@
+name: Milestone Assigned
+
+on:
+  pull_request:
+    types: [milestoned, demilestoned, opened]
+
+jobs:
+  check-milestone:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for milestone
+        run: |
+          if [ -z "${{ github.event.pull_request.milestone }}" ]; then
+            echo "No milestone assigned to the pull request."
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run Tests
+
+on: [push]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
+      - name: set up Poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: "1.2.2"
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+      - name: run pytests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: pytest

--- a/backup/rb34/field_friend.automations.implements.weeding_screw.json
+++ b/backup/rb34/field_friend.automations.implements.weeding_screw.json
@@ -3,7 +3,8 @@
     "with_chopping": false,
     "chop_if_no_crops": false,
     "cultivated_crop": null,
-    "weed_screw_depth": 0.14,
     "crop_safety_distance": 0.02,
+    "with_punch_check": false,
+    "weed_screw_depth": 0.14,
     "max_crop_distance": 0.08
 }

--- a/backup/rb34/field_friend.automations.plant_locator.json
+++ b/backup/rb34/field_friend.automations.plant_locator.json
@@ -1,7 +1,8 @@
 {
-    "minimum_weed_confidence": 0.05,
-    "minimum_crop_confidence": 0.2,
-    "autoupload": "disabled",
+    "minimum_weed_confidence": 0.3,
+    "minimum_crop_confidence": 0.3,
+    "autoupload": "filtered",
+    "upload_images": false,
     "tags": [
         "kiebitz"
     ]

--- a/backup/rb34/field_friend.automations.plant_provider.json
+++ b/backup/rb34/field_friend.automations.plant_provider.json
@@ -3,6 +3,6 @@
     "crop_spacing": 0.18,
     "predict_crop_position": false,
     "prediction_confidence": 0.3,
-    "crop_confidence_threshold": 0.3,
-    "weed_confidence_threshold": 0.1
+    "crop_confidence_threshold": 0.6,
+    "weed_confidence_threshold": 0.35
 }

--- a/config/u3_config_rb27/hardware.py
+++ b/config/u3_config_rb27/hardware.py
@@ -19,6 +19,9 @@ configuration = {'wheels': {
         'dir_pin': 4,
         'alarm_pin': 36,
         'ref_t_pin': 35,
+        'end_stops_inverted': False,
+        'acceleration': 1000,
+        'quick_stop_deceleration': 4000,
 },
     'z_axis': {
         'version': 'z_axis_stepper',
@@ -37,6 +40,9 @@ configuration = {'wheels': {
         'motor_on_expander': True,
         'end_stops_on_expander': True,
         'reversed_direction': False,
+        'end_stops_inverted': False,
+        'acceleration': 1000,
+        'quick_stop_deceleration': 4000,
 },
     'flashlight': {
         'version': 'flashlight_v2',

--- a/config/u4_config_rb28/hardware.py
+++ b/config/u4_config_rb28/hardware.py
@@ -21,6 +21,7 @@ configuration = {
         'step_pin': 5,
         'dir_pin': 4,
         'alarm_pin': 13,
+        'alarm_inverted': True,
         'end_r_pin': 19,
         'end_l_pin': 21,
         'motor_on_expander': False,

--- a/docker-compose.jetson.orin.yml
+++ b/docker-compose.jetson.orin.yml
@@ -6,7 +6,7 @@ services:
     privileged: true
 
   detector:
-    image: "zauberzeug/yolov5-detector:nlv0.10.8-35.4.1"
+    image: "zauberzeug/yolov5-detector:0.1.1-nlv0.10.9-35.4.1"
     restart: always
     ports:
       - "8004:80"
@@ -20,7 +20,7 @@ services:
       - ~/data_plants:/data
 
   # detector:
-  #   image: "zauberzeug/yolov5-detector:nlv0.8.8-35.4.1"
+  #   image: "zauberzeug/yolov5-detector:0.1.1-nlv0.10.9-35.4.1"
   #   restart: always
   #   ports:
   #     - "8004:80"
@@ -34,7 +34,7 @@ services:
   #     - ~/data_coins:/data
 
   monitoring:
-    image: "zauberzeug/yolov5-detector:nlv0.10.8-35.4.1"
+    image: "zauberzeug/yolov5-detector:0.1.1-nlv0.10.9-35.4.1"
     restart: always
     ports:
       - "8005:80"

--- a/field_friend/__init__.py
+++ b/field_friend/__init__.py
@@ -1,4 +1,12 @@
 from . import automations, hardware, interface, localization, log_configuration, vision
 from .system import System
 
-__all__ = ['automations', 'hardware', 'interface', 'localization', 'vision', 'log_configuration', 'System']
+__all__ = [
+    'automations',
+    'hardware',
+    'interface',
+    'localization',
+    'vision',
+    'log_configuration',
+    'System',
+]

--- a/field_friend/automations/automation_watcher.py
+++ b/field_friend/automations/automation_watcher.py
@@ -39,8 +39,7 @@ class AutomationWatcher:
         rosys.on_repeat(self.try_resume, 0.1)
         rosys.on_repeat(self.check_field_bounds, 1.0)
         if self.field_friend.bumper:
-            self.field_friend.bumper.BUMPER_TRIGGERED.register(
-                lambda name: self.pause(f'Bumper {name} was triggered'))
+            self.field_friend.bumper.BUMPER_TRIGGERED.register(lambda name: self.pause(f'Bumper {name} was triggered'))
         self.gnss.GNSS_CONNECTION_LOST.register(lambda: self.pause('GNSS connection lost'))
         self.gnss.RTK_FIX_LOST.register(lambda: self.pause('GNSS RTK fix lost'))
 

--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 
 import rosys
 from shapely.geometry import Polygon
@@ -23,14 +22,13 @@ class Row(GeoPointCollection):
             points=list(reversed(self.points)),
         )
 
-    def line_segment(self, reference: GeoPoint) -> rosys.geometry.LineSegment:
-        return rosys.geometry.LineSegment(point1=self.points[0].cartesian(reference),
-                                          point2=self.points[-1].cartesian(reference))
+    def line_segment(self) -> rosys.geometry.LineSegment:
+        return rosys.geometry.LineSegment(point1=self.points[0].cartesian(),
+                                          point2=self.points[-1].cartesian())
 
 
 @dataclass(slots=True, kw_only=True)
 class Field(GeoPointCollection):
-    reference: Optional[GeoPoint] = None
     visualized: bool = False
     obstacles: list[FieldObstacle] = field(default_factory=list)
     rows: list[Row] = field(default_factory=list)
@@ -38,8 +36,7 @@ class Field(GeoPointCollection):
 
     @property
     def outline(self) -> list[rosys.geometry.Point]:
-        assert self.reference is not None
-        return self.cartesian(self.reference)
+        return self.cartesian()
 
     @property
     def outline_as_tuples(self) -> list[tuple[float, float]]:

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -1,11 +1,13 @@
 import logging
+import os
 import uuid
-from typing import Any, Literal, Optional, TypedDict, Union
+from typing import Any, Optional
 
 import rosys
 from geographiclib.geodesic import Geodesic
 from rosys.geometry import Point
 
+from .. import localization
 from ..localization import GeoPoint, Gnss
 from . import Field, FieldObstacle, Row
 
@@ -43,10 +45,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
             outline = fields_data[i].get('outline_wgs84', [])
             for coords in outline:
                 f.points.append(GeoPoint(lat=coords[0], long=coords[1]))
-            rlat = fields_data[i].get('reference_lat', None)
-            rlong = fields_data[i].get('reference_lon', None)
-            if rlat is not None and rlong is not None:
-                f.reference = GeoPoint(lat=rlat, long=rlong)
             rows = fields_data[i].get('rows', [])
             for j, row in enumerate(rows):
                 for point in row.get('points_wgs84', []):
@@ -59,8 +57,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
     def create_field(self, points: list[GeoPoint] = []) -> Field:
         new_id = str(uuid.uuid4())
         field = Field(id=f'{new_id}', name=f'field_{len(self.fields)+1}', points=points)
-        if points:
-            self.set_reference(field, points[0])
         self.fields.append(field)
         self.invalidate()
         return field
@@ -75,9 +71,12 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.FIELDS_CHANGED.emit()
         self.invalidate()
 
-    def set_reference(self, field: Field, point: GeoPoint) -> None:
-        if field.reference is None:
-            field.reference = point
+    def update_reference(self) -> None:
+        if self.gnss.current is None:
+            rosys.notify('No GNSS position available.')
+            return
+        localization.reference = self.gnss.current.location
+        os.utime('main.py')
 
     def create_obstacle(self, field: Field, points: list[GeoPoint] = []) -> FieldObstacle:
         obstacle = FieldObstacle(id=f'{str(uuid.uuid4())}', name=f'obstacle_{len(field.obstacles)+1}', points=points)
@@ -141,25 +140,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.fields[field_index].rows = sorted(field.rows, key=lambda row: get_distance(row, direction=direction))
         self.FIELDS_CHANGED.emit()
 
-    def ensure_field_reference(self, field: Field) -> None:
-        if self.gnss.device is None:
-            self.log.warning('not creating Reference because no GNSS device found')
-            rosys.notify('No GNSS device found', 'negative')
-            return
-        if self.gnss.current is None or self.gnss.current.gps_qual != 4:
-            self.log.warning('not creating Reference because no RTK fix available')
-            rosys.notify('No RTK fix available', 'negative')
-            return
-        if field.reference is None:
-            ref = self.gnss.reference
-            if ref is None:
-                self.log.warning('not creating Point because no reference position available')
-                rosys.notify('No reference position available')
-                return
-            field.reference = ref
-        if self.gnss.reference != field.reference:
-            self.gnss.reference = field.reference
-
     async def add_field_point(self, field: Field, point: Optional[GeoPoint] = None, new_point: Optional[GeoPoint] = None) -> None:
         assert self.gnss.current is not None
         positioning = self.gnss.current.location
@@ -172,13 +152,8 @@ class FieldProvider(rosys.persistence.PersistentModule):
         new_point = positioning
         if point is not None:
             index = field.points.index(point)
-            if index == 0:
-                self.set_reference(field, new_point)
             field.points[index] = new_point
         else:
-            if len(field.points) < 1:
-                self.set_reference(field, new_point)
-                self.gnss.reference = new_point
             field.points.append(new_point)
         self.invalidate()
 

--- a/field_friend/automations/implements/implement.py
+++ b/field_friend/automations/implements/implement.py
@@ -24,15 +24,15 @@ class Implement(abc.ABC):
         """Deactivate the implement (for example to stop weeding at the row's end)"""
         self.is_active = False
 
-    async def observe(self) -> None:
-        """Run a custom observation in a loop; exiting will stop the robot and execute the perform_workflow method."""
+    async def get_stretch(self, max_distance: float) -> float:
+        """Return the stretch which the implement thinks is safe to drive forward."""
+        return 0.02
 
-    async def start_workflow(self) -> bool:
+    async def start_workflow(self) -> None:
         """Called after robot has stopped via observation to perform it's workflow on a specific point on the ground
 
         Returns True if the robot can drive forward, if the implement whishes to stay at the current location, return False
         """
-        return True
 
     async def stop_workflow(self) -> None:
         """Called after workflow has been performed to stop the workflow"""

--- a/field_friend/automations/implements/punch_dialog.py
+++ b/field_friend/automations/implements/punch_dialog.py
@@ -1,26 +1,26 @@
-from typing import Optional
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import rosys
 from nicegui import ui
+from rosys.automation import Automator, automation_controls
 from rosys.driving import Odometer
 from rosys.geometry import Point3d
 from rosys.vision import Image
-from rosys.automation import Automator, automation_controls
 
-from ...automations import PlantLocator
-from ...automations.plant import Plant
 from ...vision import CalibratableUsbCameraProvider, SimulatedCamProvider
+from ..plant import Plant
 
 if TYPE_CHECKING:
     from field_friend.system import System
+
+    from ...automations import PlantLocator
 
 
 class PunchDialog(ui.dialog):
     def __init__(self, system: 'System', shrink_factor: int = 1, timeout: float = 20.0, ui_update_rate: float = 0.2) -> None:
         super().__init__()
         self.camera_provider: CalibratableUsbCameraProvider | SimulatedCamProvider = system.usb_camera_provider
-        self.plant_locator: PlantLocator = system.plant_locator
+        self.plant_locator: 'PlantLocator' = system.plant_locator
         self.odometer: Odometer = system.odometer
         self.automator: Automator = system.automator
         self.shrink_factor: int = shrink_factor
@@ -57,6 +57,8 @@ class PunchDialog(ui.dialog):
         assert self.target_plant is not None
         assert self.camera is not None
         detection_image = self.camera.latest_detected_image if self.target_plant.detection_image is None else self.target_plant.detection_image
+        assert detection_image is not None
+        assert self.static_image_view is not None
         self.update_content(self.static_image_view, detection_image, draw_target=True)
         self.timer.activate()
         super().open()
@@ -68,16 +70,8 @@ class PunchDialog(ui.dialog):
     def setup_camera(self) -> None:
         cameras = list(self.camera_provider.cameras.values())
         active_camera = next((camera for camera in cameras if camera.is_connected), None)
-        if not active_camera:
-            if self.camera:
-                self.camera = None
-                self.camera_card.clear()
-                with self.camera_card:
-                    ui.label('no camera available').classes('text-center')
-                    ui.image('assets/field_friend.webp').classes('w-full')
-            return
-        if self.camera is None or self.camera != active_camera:
-            self.camera = active_camera
+        assert active_camera is not None
+        self.camera = active_camera
 
     def update_content(self, image_view: ui.interactive_image, image: Image, draw_target: bool = False) -> None:
         self._duration_left -= self.ui_update_rate
@@ -90,15 +84,21 @@ class PunchDialog(ui.dialog):
         if image and image.detections:
             target_point = None
             confidence = None
+            assert self.camera.calibration is not None
             if self.target_plant and draw_target:
                 confidence = self.target_plant.confidence
-                relative_point = self.odometer.prediction.relative_point(self.target_plant.position)
+                # TODO simplify this when https://github.com/zauberzeug/rosys/discussions/130 is available and integrated into the field friend code
+                if isinstance(self.camera_provider, SimulatedCamProvider):
+                    point = self.target_plant.position
+                else:
+                    point = self.odometer.prediction.relative_point(self.target_plant.position)
                 target_point = self.camera.calibration.project_to_image(
-                    Point3d(x=relative_point.x, y=relative_point.y, z=0))
+                    Point3d(x=point.x, y=point.y, z=0))
             image_view.set_content(self.to_svg(image.detections, target_point, confidence))
 
     def update_live_view(self) -> None:
         if self.camera is None:
+            self.live_image_view.set_source('assets/field_friend.webp')
             return
         self.update_content(self.live_image_view, self.camera.latest_detected_image)
 

--- a/field_friend/automations/implements/recorder.py
+++ b/field_friend/automations/implements/recorder.py
@@ -27,7 +27,3 @@ class Recorder(Implement):
         self.system.plant_locator.pause()
         await self.system.field_friend.flashlight.turn_off()
         await super().deactivate()
-
-    async def observe(self) -> None:
-        while True:
-            await rosys.sleep(0.5)

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -1,4 +1,5 @@
 
+from collections import deque
 from typing import TYPE_CHECKING, Any
 
 import rosys
@@ -20,53 +21,76 @@ class Tornado(WeedingImplement):
         self.drill_between_crops: bool = False
         self.field_friend = system.field_friend
 
-    async def start_workflow(self) -> bool:
+    async def start_workflow(self) -> None:
         await super().start_workflow()
         self.log.info('Performing Tornado Workflow..')
         try:
-            closest_crop_id, closest_crop_position = list(self.crops_to_handle.items())[0]
-            target_world_position = self.system.odometer.prediction.transform(closest_crop_position)
-            self.log.info(f'closest crop position: relative={closest_crop_position} world={target_world_position}')
-            # fist check if the closest crop is in the working area
-            if closest_crop_position.x >= self.system.field_friend.WORK_X + self.WORKING_DISTANCE:
-                self.log.info('closest crop is out of working area')
-                return True
-            self.log.info(f'target next crop at {closest_crop_position}')
-            if self.system.field_friend.can_reach(closest_crop_position) \
-                    and not self._crops_in_drill_range(closest_crop_id, closest_crop_position, self.tornado_angle):
-                self.log.info('drilling crop')
-                open_drill = False
-                if self.drill_with_open_tornado and not self._crops_in_drill_range(closest_crop_id, closest_crop_position, 0):
-                    open_drill = True
-                await self.system.puncher.drive_and_punch(plant_id=closest_crop_id,
-                                                          x=closest_crop_position.x,
-                                                          y=closest_crop_position.y,
-                                                          angle=self.tornado_angle,
-                                                          with_open_tornado=open_drill,
-                                                          with_punch_check=self.with_punch_check)
-                # TODO remove weeds from plant_provider and increment kpis (like in Weeding Screw)
-                if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
-                    # remove the simulated weeds
-                    inner_radius = 0.025  # TODO compute inner radius according to tornado angle
-                    outer_radius = inner_radius + 0.05  # TODO compute outer radius according to inner radius and knife width
-                    self.system.detector.simulated_objects = [obj for obj in self.system.detector.simulated_objects
-                                                              if not (inner_radius <= obj.position.projection().distance(target_world_position) <= outer_radius)]
-
+            # TODO: do we need to set self.next_crop_id = '' on every return?
+            punch_position = self.system.odometer.prediction.transform(
+                rosys.geometry.Point(x=self.system.field_friend.WORK_X, y=self.next_punch_y_position))
+            self.last_punches.append(punch_position)
+            self.log.info(f'Drilling crop at {punch_position} with angle {self.tornado_angle}°')
+            open_drill = False
+            if self.drill_with_open_tornado:
+                open_drill = True
+            await self.system.puncher.punch(y=self.next_punch_y_position, angle=self.tornado_angle, with_open_tornado=open_drill)
+            # TODO remove weeds from plant_provider and increment kpis (like in Weeding Screw)
+            if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
+                # remove the simulated weeds
+                inner_radius = 0.025  # TODO compute inner radius according to tornado angle
+                outer_radius = inner_radius + 0.05  # TODO compute outer radius according to inner radius and knife width
+                # inner_diameter, outer_diameter = self.system.field_friend.tornado_diameters(self.tornado_angle)
+                # inner_radius = inner_diameter / 2
+                # outer_radius = outer_diameter / 2
+                self.system.detector.simulated_objects = [obj for obj in self.system.detector.simulated_objects
+                                                          if not (inner_radius <= obj.position.projection().distance(punch_position) <= outer_radius)]
+                self.log.info(f'simulated_objects2: {len(self.system.detector.simulated_objects)}')
             return True
         except PuncherException:
             self.log.error('Error in Tornado Workflow')
-            return True
         except Exception as e:
             raise ImplementException('Error while tornado Workflow') from e
 
-    def _has_plants_to_handle(self) -> bool:
+    async def get_stretch(self, max_distance: float) -> float:
+        await super().get_stretch(max_distance)
         super()._has_plants_to_handle()
-        return any(self.crops_to_handle)
+        if len(self.crops_to_handle) == 0:
+            return self.WORKING_DISTANCE
+        closest_crop_id, closest_crop_position = list(self.crops_to_handle.items())[0]
+        closest_crop_world_position = self.system.odometer.prediction.transform(closest_crop_position)
+
+        # for p in self.last_punches:
+        #     self.log.info(f'Last punch: {p} - {p.distance(closest_crop_world_position)} - {self.crop_safety_distance} - {closest_crop_world_position}')
+        if any(p.distance(closest_crop_world_position) < self.field_friend.DRILL_RADIUS for p in self.last_punches):
+            self.log.info('Skipping weed because it was already punched')
+            return self.WORKING_DISTANCE
+        if not self.system.field_friend.can_reach(closest_crop_position):
+            self.log.info('Target crop is not reachable')
+            return self.WORKING_DISTANCE
+        if closest_crop_position.x >= self.system.field_friend.WORK_X + self.WORKING_DISTANCE:
+            self.log.info('Closest crop is out of working area')
+            return self.WORKING_DISTANCE
+        if self._crops_in_drill_range(closest_crop_id, closest_crop_position, self.tornado_angle):
+            self.log.info('Crops in drill range')
+            return self.WORKING_DISTANCE
+
+        stretch = closest_crop_position.x - self.system.field_friend.WORK_X
+        if stretch < - self.system.field_friend.DRILL_RADIUS:
+            self.log.info(f'Skipping crop {closest_crop_id} because it is behind the robot')
+            return self.WORKING_DISTANCE
+        if stretch < 0:
+            stretch = 0
+        self.log.info(f'Targeting crop {closest_crop_id} which is {stretch} away at world: '
+                      f'{closest_crop_world_position}, local: {closest_crop_position}')
+        if stretch < max_distance and await self.ask_for_punch(closest_crop_id):
+            self.next_punch_y_position = closest_crop_position.y
+            return stretch
+        return self.WORKING_DISTANCE
 
     def _crops_in_drill_range(self, crop_id: str, crop_position: rosys.geometry.Point, angle: float) -> bool:
         inner_diameter, outer_diameter = self.system.field_friend.tornado_diameters(angle)
+        crop_world_position = self.system.odometer.prediction.transform(crop_position)
         for crop in self.system.plant_provider.crops:
-            crop_world_position = self.system.odometer.prediction.transform(crop_position)
             if crop.id != crop_id:
                 distance = crop_world_position.distance(crop.position)
                 if distance >= inner_diameter/2 and distance <= outer_diameter/2:

--- a/field_friend/automations/implements/weeding_screw.py
+++ b/field_friend/automations/implements/weeding_screw.py
@@ -17,94 +17,87 @@ class WeedingScrew(WeedingImplement):
         self.relevant_weeds = system.small_weed_category_names + system.big_weed_category_names
         self.log.info(f'Using relevant weeds: {self.relevant_weeds}')
         self.weed_screw_depth: float = 0.13
-        self.crop_safety_distance: float = 0.01
         self.max_crop_distance: float = 0.08
 
-    async def start_workflow(self) -> bool:
+    async def start_workflow(self) -> None:
         await super().start_workflow()
         try:
-            self._keep_crops_safe()
-            weeds_in_range = {weed_id: position for weed_id, position in self.weeds_to_handle.items()
-                              if self.system.field_friend.can_reach(position)}
-            if not weeds_in_range:
-                self.log.info('No weeds in range')
-                return True
-            self.log.info(f'Weeds in range {[f"{p.x:.3f},{p.y:.3f}" for p in weeds_in_range.values()]}')
-            for next_weed_id, next_weed_position in weeds_in_range.items():
-                weed_world_position = self.system.odometer.prediction.transform(next_weed_position)
-                crops = self.system.plant_provider.get_relevant_crops(self.system.odometer.prediction.point)
-                if self.cultivated_crop and not any(c.position.distance(weed_world_position) < self.max_crop_distance for c in crops):
-                    self.log.info('Skipping weed because it is to far from the cultivated crops')
-                    continue
-                next_weed_position.x += 0.01  # NOTE somehow this helps to mitigate an offset we experienced in the tests
-                self.log.info(f'Targeting weed at world: {weed_world_position}, local: {next_weed_position}')
-                await self.system.puncher.drive_and_punch(plant_id=next_weed_id,
-                                                          x=next_weed_position.x,
-                                                          y=next_weed_position.y,
-                                                          depth=self.weed_screw_depth,
-                                                          with_punch_check=self.with_punch_check,
-                                                          backwards_allowed=False)
-                punched_weeds = [weed_id for weed_id, position in weeds_in_range.items()
-                                 if position.distance(next_weed_position) <= self.system.field_friend.DRILL_RADIUS
-                                 or weed_id == next_weed_id]
-                for weed_id in punched_weeds:
-                    self.system.plant_provider.remove_weed(weed_id)
-                    if weed_id in weeds_in_range:
-                        del weeds_in_range[weed_id]
-                    self.kpi_provider.increment_weeding_kpi('weeds_removed')
-                if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
-                    screw_world_position = self.system.odometer.prediction.transform(
-                        rosys.geometry.Point(x=self.system.field_friend.WORK_X, y=self.system.field_friend.y_axis.position))
-                    self.log.info(f'removing weeds at screw world position {screw_world_position} '
-                                  f'with radius {self.system.field_friend.DRILL_RADIUS}')
-                    self.system.detector.simulated_objects = [
-                        obj for obj in self.system.detector.simulated_objects
-                        if obj.position.projection().distance(screw_world_position) > self.system.field_friend.DRILL_RADIUS]
-                return False  # NOTE do not advance after punching a weed, there might be more at this robots position
+            punch_position = self.system.odometer.prediction.transform(
+                rosys.geometry.Point(x=self.system.field_friend.WORK_X, y=self.next_punch_y_position))
+            self.last_punches.append(punch_position)
+            await self.system.puncher.punch(y=self.next_punch_y_position, depth=self.weed_screw_depth)
+            punched_weeds = [weed.id for weed in self.system.plant_provider.get_relevant_weeds(self.system.odometer.prediction.point)
+                             if weed.position.distance(punch_position) <= self.system.field_friend.DRILL_RADIUS]
+            for weed_id in punched_weeds:
+                self.system.plant_provider.remove_weed(weed_id)
+                self.kpi_provider.increment_weeding_kpi('weeds_removed')
+            if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
+                self.log.info(f'removing weeds at screw world position {punch_position} '
+                              f'with radius {self.system.field_friend.DRILL_RADIUS}')
+                self.system.detector.simulated_objects = [
+                    obj for obj in self.system.detector.simulated_objects
+                    if obj.position.projection().distance(punch_position) > self.system.field_friend.DRILL_RADIUS]
             return True  # NOTE no weeds to work on at this position -> advance robot
         except Exception as e:
-            raise ImplementException(f'Error while Weed Screw Workflow: {e}') from e
+            raise ImplementException(f'Error in Weed Screw Workflow: {e}') from e
 
-    def _has_plants_to_handle(self) -> bool:
+    async def get_stretch(self, max_distance: float) -> float:
+        await super().get_stretch(max_distance)
         super()._has_plants_to_handle()
-        return any(self.weeds_to_handle)
+        weeds_in_range = {weed_id: position for weed_id, position in self.weeds_to_handle.items()
+                          if self.system.field_friend.can_reach(position)}
+        if not weeds_in_range:
+            self.log.info('No weeds in range')
+            return self.WORKING_DISTANCE
+        self.log.info(f'Found {len(weeds_in_range)} weeds in range: {weeds_in_range}')
+        for next_weed_id, next_weed_position in weeds_in_range.items():
+            # next_weed_position.x += 0.01  # NOTE somehow this helps to mitigate an offset we experienced in the tests
+            weed_world_position = self.system.odometer.prediction.transform(next_weed_position)
+            crops = self.system.plant_provider.get_relevant_crops(self.system.odometer.prediction.point)
+            if self.cultivated_crop and not any(c.position.distance(weed_world_position) < self.max_crop_distance for c in crops):
+                self.log.info('Skipping weed because it is to far from the cultivated crops')
+                continue
+            if any(p.distance(weed_world_position) < self.system.field_friend.DRILL_RADIUS for p in self.last_punches):
+                self.log.info('Skipping weed because it was already punched')
+                continue
+            stretch = next_weed_position.x - self.system.field_friend.WORK_X
+            if stretch < - self.system.field_friend.DRILL_RADIUS:
+                self.log.info(f'Skipping weed {next_weed_id} because it is behind the robot')
+                continue
+            if stretch < 0:
+                stretch = 0
+            self.log.info(f'Targeting weed {next_weed_id} which is {stretch} away at world: '
+                          f'{weed_world_position}, local: {next_weed_position}')
+            if stretch < max_distance and await self.ask_for_punch(next_weed_id):
+                self.next_punch_y_position = next_weed_position.y
+                return stretch
+            else:
+                break
+        return self.WORKING_DISTANCE
 
     def settings_ui(self):
         super().settings_ui()
         ui.number('Drill depth', format='%.2f', step=0.01,
-                  min=self.system.field_friend.z_axis.max_position, max=self.system.field_friend.z_axis.min_position*-1) \
+                  min=self.system.field_friend.z_axis.max_position,
+                  max=self.system.field_friend.z_axis.min_position*-1,
+                  on_change=self.request_backup) \
             .props('dense outlined suffix=°') \
             .classes('w-24') \
             .bind_value(self, 'weed_screw_depth') \
             .tooltip('Set the drill depth for the weeding automation')
-        ui.number('Crop safety distance', step=0.001, min=0.001, max=0.05, format='%.3f') \
+        ui.number('Maximum weed distance from crop', step=0.001, min=0.001, max=1.00, format='%.3f', on_change=self.request_backup) \
             .props('dense outlined suffix=m') \
             .classes('w-24') \
-            .bind_value(self, 'crop_safety_distance') \
-            .tooltip('Set the crop safety distance for the weeding automation')
-
-    def _keep_crops_safe(self) -> None:
-        self.log.info('Keeping crops safe...')
-        for crop in self.system.plant_provider.crops:
-            crop_position = self.system.odometer.prediction.relative_point(crop.position)
-            for weed, weed_position in self.weeds_to_handle.items():
-                offset = self.system.field_friend.DRILL_RADIUS + \
-                    self.crop_safety_distance - crop_position.distance(weed_position)
-                if offset > 0:
-                    safe_weed_position = weed_position.polar(offset, crop_position.direction(weed_position))
-                    self.weeds_to_handle[weed] = safe_weed_position
-                    self.log.info(f'Moved weed {weed} from {weed_position} to {safe_weed_position} ' +
-                                  f'by {offset} to safe {crop.id} at {crop_position}')
+            .bind_value(self, 'max_crop_distance') \
+            .tooltip('Set the maximum distance a weed can be away from a crop to be considered for weeding')
 
     def backup(self) -> dict:
         return super().backup() | {
             'weed_screw_depth': self.weed_screw_depth,
-            'crop_safety_distance': self.crop_safety_distance,
             'max_crop_distance': self.max_crop_distance,
         }
 
     def restore(self, data: dict[str, Any]) -> None:
         super().restore(data)
         self.weed_screw_depth = data.get('weed_screw_depth', self.weed_screw_depth)
-        self.crop_safety_distance = data.get('crop_safety_distance', self.crop_safety_distance)
         self.max_crop_distance = data.get('max_crop_distance', self.max_crop_distance)

--- a/field_friend/automations/navigation/coverage_navigation.py
+++ b/field_friend/automations/navigation/coverage_navigation.py
@@ -84,21 +84,16 @@ class CoverageNavigation(Navigation):
             self.log.error('Field is not available')
             rosys.notify('No field selected', 'negative')
             return False
-        if not self.field.reference:
-            self.log.error('Field reference is not available')
-            return False
-        self.system.gnss.reference = self.field.reference
         if self.padding < self.robot_width+self.lane_distance:
             self.padding = self.robot_width+self.lane_distance
 
         self.path_planner.obstacles.clear()
         self.path_planner.areas.clear()
         assert self.field is not None
-        assert self.field.reference is not None
         for obstacle in self.field.obstacles:
             self.path_planner.obstacles[obstacle.id] = \
                 rosys.pathplanning.Obstacle(id=obstacle.id,
-                                            outline=obstacle.cartesian(self.field.reference))
+                                            outline=obstacle.cartesian())
         area = rosys.pathplanning.Area(id=f'{self.field.id}', outline=self.field.outline)
         self.path_planner.areas = {area.id: area}
         self.paths = self._generate_mowing_path()
@@ -124,8 +119,8 @@ class CoverageNavigation(Navigation):
 
         return True
 
-    async def _drive(self) -> None:
-        return await super()._drive()
+    async def _drive(self, distance: float) -> None:
+        return await super()._drive(distance)
 
     def _should_finish(self) -> bool:
         return False

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -1,8 +1,10 @@
 import abc
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
 import rosys
+from rosys.helpers import angle
 from nicegui import ui
 
 from ..implements import Implement
@@ -16,6 +18,8 @@ class WorkflowException(Exception):
 
 
 class Navigation(rosys.persistence.PersistentModule):
+    MAX_STRETCH_DISTANCE = 0.05
+    DEFAULT_DRIVE_DISTANCE = 0.02
 
     def __init__(self, system: 'System', implement: Implement) -> None:
         super().__init__()
@@ -26,13 +30,14 @@ class Navigation(rosys.persistence.PersistentModule):
         self.plant_provider = system.plant_provider
         self.puncher = system.puncher
         self.implement = implement
+        self.detector = system.detector
         self.name = 'Unknown'
         self.start_position = self.odometer.prediction.point
+        self.linear_speed_limit = 0.125
+        self.angular_speed_limit = 0.1
 
     async def start(self) -> None:
         try:
-            if isinstance(self.driver.wheels, rosys.hardware.WheelsSimulation) and not rosys.is_test:
-                self.create_simulation()
             if not await self.implement.prepare():
                 self.log.error('Tool-Preparation failed')
                 return
@@ -40,17 +45,16 @@ class Navigation(rosys.persistence.PersistentModule):
                 self.log.error('Preparation failed')
                 return
             self.start_position = self.odometer.prediction.point
+            if isinstance(self.driver.wheels, rosys.hardware.WheelsSimulation) and not rosys.is_test:
+                self.create_simulation()
             while not self._should_finish():
-                await rosys.automation.parallelize(
-                    self.implement.observe(),
-                    self._proceed(),
-                    return_when_first_completed=True
-                )
-                if not self._should_finish():
-                    should_advance = await self.implement.start_workflow()
-                    await self.implement.stop_workflow()
-                    if should_advance:
-                        await self._drive()
+                distance = await self.implement.get_stretch(self.MAX_STRETCH_DISTANCE)
+                if distance > self.MAX_STRETCH_DISTANCE:  # we do not want to drive to long without observing
+                    await self._drive(self.DEFAULT_DRIVE_DISTANCE)
+                    continue
+                await self._drive(distance)
+                await self.implement.start_workflow()
+                await self.implement.stop_workflow()
         except WorkflowException as e:
             self.kpi_provider.increment_weeding_kpi('automation_stopped')
             self.log.error(f'WorkflowException: {e}')
@@ -64,22 +68,32 @@ class Navigation(rosys.persistence.PersistentModule):
         """Prepares the navigation for the start of the automation
 
         Returns true if all preparations were successful, otherwise false."""
+        self.plant_provider.clear()
+        if isinstance(self.detector, rosys.vision.DetectorSimulation) and not rosys.is_test:
+            self.detector.simulated_objects = []
+        self.log.info('clearing plant provider')
         return True
 
     async def finish(self) -> None:
         """Executed after the navigation is done"""
 
-    async def _proceed(self):
-        while not self._should_finish():
-            await self._drive()
-
     @abc.abstractmethod
-    async def _drive(self) -> None:
-        """Drives the vehicle forward
+    async def _drive(self, distance: float) -> None:
+        """Drives the vehicle a short distance forward"""
 
-        This should only advance the robot by a small distance, e.g. 2 cm 
-        to allow for adjustments and observations.
-        """
+    async def _drive_to_yaw(self, distance: float, yaw: float):
+        deadline = rosys.time() + 2
+        start_position = self.odometer.prediction.point
+        yaw = angle(self.odometer.prediction.yaw, yaw) # take current yaw into account and only steer the difference
+        with self.driver.parameters.set(linear_speed_limit=self.linear_speed_limit, angular_speed_limit=self.angular_speed_limit):
+            await self.driver.wheels.drive(*self.driver._throttle(1, yaw))  # pylint: disable=protected-access
+        try:
+            while self.odometer.prediction.point.distance(start_position) < distance:
+                if rosys.time() >= deadline:
+                    raise TimeoutError('Driving Timeout')
+                await rosys.sleep(0.01)
+        finally:
+            await self.driver.wheels.stop()
 
     @abc.abstractmethod
     def _should_finish(self) -> bool:

--- a/field_friend/automations/navigation/row_on_field_navigation.py
+++ b/field_friend/automations/navigation/row_on_field_navigation.py
@@ -39,9 +39,6 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         if self.field is None:
             rosys.notify('No field selected', 'negative')
             return False
-        if not self.field.reference:
-            rosys.notify('No field reference available', 'negative')
-            return False
         if not self.field.rows:
             rosys.notify('No rows available', 'negative')
             return False
@@ -55,13 +52,11 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         if self.state == self.State.FIELD_COMPLETED:
             self.clear()
         if self.state == self.State.FOLLOWING_ROW:
-            if self.current_row.line_segment(self.field.reference).distance(self.odometer.prediction.point) > 0.1:
+            if self.current_row.line_segment().distance(self.odometer.prediction.point) > 0.1:
                 self.clear()
         else:
             self.plant_provider.clear()
 
-        # NOTE: it's useful to set the reference point to the reference of the field; that way the cartesian coordinates are simpler to comprehend
-        self.gnss.reference = self.field.reference
         await rosys.sleep(0.1)  # wait for GNSS to update
         self.automation_watcher.start_field_watch(self.field.outline)
         return True
@@ -70,9 +65,8 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         await super().finish()
         self.automation_watcher.stop_field_watch()
 
-    async def _drive(self) -> None:
+    async def _drive(self, distance: float) -> None:
         assert self.field is not None
-        assert self.field.reference is not None
         if self.state == self.State.APPROACHING_ROW_START:
             # TODO only drive to row if we are not on any rows and near the row start
             await self._drive_to_row(self.current_row)
@@ -82,20 +76,20 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         if self.state == self.State.FOLLOWING_ROW:
             if not self.implement.is_active:
                 await self.implement.activate()
-            if self.odometer.prediction.point.distance(self.current_row.points[-1].cartesian(self.field.reference)) >= 0.1:
-                await super()._drive()
+            if self.odometer.prediction.point.distance(self.current_row.points[-1].cartesian()) >= 0.1:
+                await super()._drive(distance)
             else:
                 await self.implement.deactivate()
                 self.state = self.State.RETURNING_TO_START
                 self.log.info('Returning to start...')
         if self.state == self.State.RETURNING_TO_START:
             self.driver.parameters.can_drive_backwards = True
-            end = self.current_row.points[0].cartesian(self.field.reference)
+            end = self.current_row.points[0].cartesian()
             await self.driver.drive_to(end, backward=True)  # TODO replace with following crops or replay recorded path
             inverse_yaw = (self.odometer.prediction.yaw + math.pi) % (2 * math.pi)
             next_row = self.field.rows[self.row_index + 1] if self.row_index + \
                 1 < len(self.field.rows) else self.current_row
-            between = end.interpolate(next_row.points[0].cartesian(self.field.reference), 0.5)
+            between = end.interpolate(next_row.points[0].cartesian(), 0.5)
             await self.driver.drive_to(between.polar(1.5, inverse_yaw), backward=True)
             self.driver.parameters.can_drive_backwards = False
             self.state = self.State.ROW_COMPLETED
@@ -112,9 +106,9 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
 
     async def _drive_to_row(self, row: Row):
         self.log.info(f'Driving to "{row.name}"...')
-        assert self.field and self.field.reference
-        target = row.points[0].cartesian(self.field.reference)
-        direction = target.direction(row.points[-1].cartesian(self.field.reference))
+        assert self.field
+        target = row.points[0].cartesian()
+        direction = target.direction(row.points[-1].cartesian())
         end_pose = Pose(x=target.x, y=target.y, yaw=direction)
         spline = Spline.from_poses(self.odometer.prediction, end_pose)
         await self.driver.drive_spline(spline)
@@ -162,11 +156,10 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         self.detector.simulated_objects.clear()
         if self.field is None:
             return
-        assert self.field.reference is not None
         for row in self.field.rows:
             if len(row.points) < 2:
                 continue
-            cartesian = row.cartesian(self.field.reference)
+            cartesian = row.cartesian()
             start = cartesian[0]
             end = cartesian[-1]
             length = start.distance(end)

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -1,3 +1,4 @@
+import asyncio
 from random import randint
 from typing import TYPE_CHECKING, Any
 
@@ -20,27 +21,31 @@ class StraightLineNavigation(Navigation):
         self.detector = system.detector
         self.length = 2.0
         self.name = 'Straight Line'
-        self.linear_speed_limit = 0.125
-        self.angular_speed_limit = 0.1
+        self.origin: rosys.geometry.Point
+        self.target: rosys.geometry.Point
 
     async def prepare(self) -> bool:
+        await super().prepare()
         self.log.info(f'Activating {self.implement.name}...')
-        self.plant_provider.clear()
+        self.origin = self.odometer.prediction.point
+        self.target = self.odometer.prediction.transform(rosys.geometry.Point(x=self.length, y=0))
         await self.implement.activate()
         return True
 
     async def finish(self) -> None:
+        await super().finish()
         await self.implement.deactivate()
 
-    async def _drive(self):
-        target = self.odometer.prediction.transform(rosys.geometry.Point(x=0.02, y=0))
-        # self.log.info(f'driving to {target}')
-        with self.driver.parameters.set(linear_speed_limit=self.linear_speed_limit, angular_speed_limit=self.angular_speed_limit):
-            await self.driver.drive_to(target)
+    async def _drive(self, distance: float):
+        start_position = self.odometer.prediction.point
+        closest_point = rosys.geometry.Line.from_points(self.origin, self.target).foot_point(start_position)
+        local_target = rosys.geometry.Pose(x=closest_point.x, y=closest_point.y, yaw=start_position.direction(self.target), time=0) \
+            .transform(rosys.geometry.Point(x=1, y=0))
+        await self._drive_to_yaw(distance, start_position.direction(local_target))
 
     def _should_finish(self):
-        distance = self.odometer.prediction.point.distance(self.start_position)
-        return abs(distance - self.length) < 0.05
+        end_pose = rosys.geometry.Pose(x=self.target.x, y=self.target.y, yaw=self.origin.direction(self.target), time=0)
+        return end_pose.relative_point(self.odometer.prediction.point).x > 0
 
     def create_simulation(self):
         crop_distance = 0.2

--- a/field_friend/automations/path_provider.py
+++ b/field_friend/automations/path_provider.py
@@ -10,7 +10,6 @@ from ..localization import GeoPoint
 class Path:
     name: str
     path_segments: list[rosys.driving.PathSegment] = field(default_factory=list)
-    reference: Optional[GeoPoint] = None
     visualized: bool = False
 
 

--- a/field_friend/automations/path_recorder.py
+++ b/field_friend/automations/path_recorder.py
@@ -36,11 +36,6 @@ class PathRecorder():
             self.log.warning(f'not recording path "{path.name}" not found')
             return
         self.log.info(f'recording path {path.name}')
-        if self.gnss.device != 'simulation':
-            if self.gnss.reference is None:
-                self.log.warning('not recording because no reference location set')
-                return
-            path.reference = self.gnss.reference
         rosys.notify(f'Recording...Please drive the path {path.name} now.')
         self.current_path_recording = path.name
         self.state = 'recording'
@@ -84,17 +79,6 @@ class PathRecorder():
         if path == []:
             self.log.warning(f'path {path.name} is empty')
             return
-        if self.gnss.device != 'simulation':
-            if path.reference is None:
-                self.log.warning('not driving because no reference location set')
-                return
-            # NOTE the target location is the path reference point; we do not approach a path if it is to far away
-            self.gnss.reference = path.reference
-            distance = self.gnss.distance(self.gnss.current)
-            if not distance or distance > 10:
-                self.log.warning('not driving because distance to reference location is too large')
-                rosys.notify('Distance to reference location is too large', 'negative')
-                return
         self.log.info(f'path: {path}')
         self.current_path_driving = path.name
         rosys.notify(f'Driving path {path.name}...', 'info')

--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -1,11 +1,9 @@
-import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Optional
-import aiohttp
+from typing import TYPE_CHECKING, Any
 
+import aiohttp
 import rosys
 from nicegui import ui
-from nicegui.events import ValueChangeEventArguments
 from rosys.vision import Autoupload
 
 from ..vision import SimulatedCam
@@ -38,7 +36,7 @@ class PlantLocator(rosys.persistence.PersistentModule):
         self.tags: list[str] = []
         self.is_paused = True
         self.autoupload: Autoupload = Autoupload.DISABLED
-        self.upload_images: bool = False 
+        self.upload_images: bool = False
         self.weed_category_names: list[str] = WEED_CATEGORY_NAME
         self.crop_category_names: list[str] = CROP_CATEGORY_NAME
         self.minimum_weed_confidence: float = MINIMUM_WEED_CONFIDENCE
@@ -140,14 +138,14 @@ class PlantLocator(rosys.persistence.PersistentModule):
 
     async def get_outbox_mode(self, port: int) -> bool:
         # TODO: not needed right now, but can be used when this code is moved to the DetectorHardware code
-        url = f'http://localhost:{port}/outbox_mode'            
+        url = f'http://localhost:{port}/outbox_mode'
         async with aiohttp.request('GET', url) as response:
             if response.status != 200:
                 self.log.error(f'Could not get outbox mode on port {port} - status code: {response.status}')
                 return None
             response_text = await response.text()
         return response_text == 'continuous_upload'
-    
+
     async def set_outbox_mode(self, value: bool, port: int) -> None:
         url = f'http://localhost:{port}/outbox_mode'
         async with aiohttp.request('PUT', url, data='continuous_upload' if value else 'stopped') as response:
@@ -172,7 +170,8 @@ class PlantLocator(rosys.persistence.PersistentModule):
             .bind_value(self, 'autoupload') \
             .classes('w-24').tooltip('Set the autoupload for the weeding automation')
         if isinstance(self.detector, rosys.vision.DetectorHardware):
-            ui.checkbox('Upload images', on_change=self.request_backup).bind_value(self, 'upload_images').on('click', lambda: self.set_outbox_mode(value=self.upload_images, port=self.detector.port))        
+            ui.checkbox('Upload images', on_change=self.request_backup).bind_value(self, 'upload_images') \
+                .on('click', lambda: self.set_outbox_mode(value=self.upload_images, port=self.detector.port))
 
         @ui.refreshable
         def chips():

--- a/field_friend/automations/plant_provider.py
+++ b/field_friend/automations/plant_provider.py
@@ -15,6 +15,7 @@ def check_if_plant_exists(plant: Plant, plants: list[Plant], distance: float) ->
             p.confidences.append(plant.confidence)
             p.positions.append(plant.position)
             p.detection_image = plant.detection_image
+            p.detection_time = plant.detection_time
             return True
     return False
 
@@ -77,7 +78,7 @@ class PlantProvider(rosys.persistence.PersistentModule):
         raise ValueError(f'Plant with ID {plant_id} not found')
 
     async def add_weed(self, weed: Plant) -> None:
-        if check_if_plant_exists(weed, self.weeds, 0.04):
+        if check_if_plant_exists(weed, self.weeds, 0.02):
             return
         self.weeds.append(weed)
         self.PLANTS_CHANGED.emit()
@@ -94,7 +95,8 @@ class PlantProvider(rosys.persistence.PersistentModule):
     def add_crop(self, crop: Plant) -> None:
         if check_if_plant_exists(crop, self.crops, self.match_distance):
             return
-        self._add_crop_prediction(crop)
+        if self.predict_crop_position:
+            self._add_crop_prediction(crop)
         self.crops.append(crop)
         self.PLANTS_CHANGED.emit()
         self.ADDED_NEW_CROP.emit()
@@ -112,8 +114,6 @@ class PlantProvider(rosys.persistence.PersistentModule):
         self.clear_crops()
 
     def _add_crop_prediction(self, plant: Plant) -> None:
-        if not self.predict_crop_position:
-            return
         sorted_crops = sorted(self.crops, key=lambda crop: crop.position.distance(plant.position))
         if len(sorted_crops) < 2:
             return

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -17,8 +17,6 @@ class PuncherException(Exception):
 
 class Puncher:
     def __init__(self, field_friend: FieldFriend, driver: Driver, kpi_provider: KpiProvider) -> None:
-        self.POSSIBLE_PUNCH = rosys.event.Event()
-        '''Event that is emitted when a punch is possible.'''
         self.punch_allowed: str = 'waiting'
         self.field_friend = field_friend
         self.driver = driver
@@ -49,7 +47,7 @@ class Puncher:
         if self.field_friend.y_axis is None or self.field_friend.z_axis is None:
             rosys.notify('no y or z axis', 'negative')
             return
-        self.log.info(f'Driving to punch at {local_target_x}...')
+        self.log.info(f'Driving to punch at {local_target_x:.2f}...')
         work_x = self.field_friend.WORK_X
         if local_target_x < work_x:
             self.log.info(f'Target: {local_target_x} is behind')
@@ -64,9 +62,7 @@ class Puncher:
                     depth: float = 0.01,
                     angle: float = 180,
                     turns: float = 2.0,
-                    plant_id: Optional[str] = None,
                     with_open_tornado: bool = False,
-                    with_punch_check: bool = False,
                     ) -> None:
         self.log.info(f'Punching at {y} with depth {depth}...')
         rest_position = 'reference'
@@ -92,16 +88,6 @@ class Puncher:
                 if not self.field_friend.y_axis.min_position <= y <= self.field_friend.y_axis.max_position:
                     rosys.notify('y position out of range', type='negative')
                     raise PuncherException('y position out of range')
-                
-            if with_punch_check and plant_id is not None:
-                self.punch_allowed = 'waiting'
-                self.POSSIBLE_PUNCH.emit(plant_id)
-                while self.punch_allowed == 'waiting':
-                    await rosys.sleep(0.1)
-                if self.punch_allowed == 'not_allowed':
-                    self.log.warning('punch was not allowed')
-                    return
-                self.log.info('punching was allowed')
 
             if isinstance(self.field_friend.z_axis, Tornado):
                 await self.field_friend.y_axis.move_to(y)
@@ -119,7 +105,7 @@ class Puncher:
             self.log.info(f'punched at {y:.2f} with depth {depth}, now back to rest position "{rest_position}"')
             self.kpi_provider.increment_weeding_kpi('punches')
         except Exception as e:
-            raise PuncherException(f'punching failed because: {e}') from e
+            raise PuncherException('punching failed') from e
         finally:
             await self.field_friend.y_axis.stop()
             await self.field_friend.z_axis.stop()

--- a/field_friend/hardware/field_friend_hardware.py
+++ b/field_friend/hardware/field_friend_hardware.py
@@ -1,9 +1,9 @@
 import logging
 
 import numpy as np
-import rosys
 
 import config.config_selection as config_selector
+import rosys
 
 from .can_open_master import CanOpenMasterHardware
 from .chain_axis import ChainAxisHardware
@@ -118,7 +118,8 @@ class FieldFriendHardware(FieldFriend, rosys.hardware.RobotHardware):
             try:
                 alarm_inverted: bool = config_hardware['y_axis']['alarm_inverted']
             except KeyError:
-                raise KeyError('\'alarm_inverted\' not found in config_hardware[\'y_axis\']. U4 has an inverted motor alarm input. Check your robot\'s setup.')
+                raise KeyError(
+                    '\'alarm_inverted\' not found in config_hardware[\'y_axis\']. Robots with a Closed-Loop-Step-Direction-Motor (U4 and before) has an inverted motor alarm input. Check your robot\'s setup.')
             y_axis = YAxisStepperHardware(robot_brain,
                                           expander=expander,
                                           name=config_hardware['y_axis']['name'],

--- a/field_friend/hardware/field_friend_hardware.py
+++ b/field_friend/hardware/field_friend_hardware.py
@@ -115,6 +115,10 @@ class FieldFriendHardware(FieldFriend, rosys.hardware.RobotHardware):
                                        end_stops_on_expander=config_hardware['y_axis']['end_stops_on_expander'],
                                        )
         elif config_hardware['y_axis']['version'] == 'y_axis_stepper':
+            try:
+                alarm_inverted: bool = config_hardware['y_axis']['alarm_inverted']
+            except KeyError:
+                raise KeyError('\'alarm_inverted\' not found in config_hardware[\'y_axis\']. U4 has an inverted motor alarm input. Check your robot\'s setup.')
             y_axis = YAxisStepperHardware(robot_brain,
                                           expander=expander,
                                           name=config_hardware['y_axis']['name'],
@@ -127,6 +131,7 @@ class FieldFriendHardware(FieldFriend, rosys.hardware.RobotHardware):
                                           step_pin=config_hardware['y_axis']['step_pin'],
                                           dir_pin=config_hardware['y_axis']['dir_pin'],
                                           alarm_pin=config_hardware['y_axis']['alarm_pin'],
+                                          alarm_inverted=alarm_inverted,
                                           end_r_pin=config_hardware['y_axis']['end_r_pin'],
                                           end_l_pin=config_hardware['y_axis']['end_l_pin'],
                                           motor_on_expander=config_hardware['y_axis']['motor_on_expander'],

--- a/field_friend/hardware/field_friend_simulation.py
+++ b/field_friend/hardware/field_friend_simulation.py
@@ -37,7 +37,7 @@ class FieldFriendSimulation(FieldFriend, rosys.hardware.RobotSimulation):
             self.CHOP_RADIUS = config_params['chop_radius']
         else:
             raise NotImplementedError(f'Unknown FieldFriend tool: {tool}')
-        wheels = rosys.hardware.WheelsSimulation()
+        wheels = rosys.hardware.WheelsSimulation(self.WHEEL_DISTANCE)
 
         y_axis: YAxisSimulation | ChainAxisSimulation | None
         if config_hardware['y_axis']['version'] == 'chain_axis':

--- a/field_friend/hardware/y_axis_stepper_hardware.py
+++ b/field_friend/hardware/y_axis_stepper_hardware.py
@@ -21,6 +21,7 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
                  step_pin: int = 5,
                  dir_pin: int = 4,
                  alarm_pin: int = 36,
+                 alarm_inverted: bool = True,
                  end_r_pin: int = 19,
                  end_l_pin: int = 21,
                  motor_on_expander: bool = False,
@@ -33,7 +34,7 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
         lizard_code = remove_indentation(f'''
             {name}_motor = {expander.name + "." if motor_on_expander and expander else ""}StepperMotor({step_pin}, {dir_pin})
             {name}_alarm = {expander.name + "." if motor_on_expander and expander else ""}Input({alarm_pin})
-            {name}_alarm.inverted = true 
+            {name}_alarm.inverted = {str(alarm_inverted).lower()} 
             {name}_end_l = {expander.name + "." if end_stops_on_expander and expander else ""}Input({end_l_pin})
             {name}_end_l.inverted = {str(end_stops_inverted).lower()}
             {name}_end_r = {expander.name + "." if end_stops_on_expander and expander else ""}Input({end_r_pin})
@@ -158,6 +159,5 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
         self.idle = words.pop(0) == 'true'
         self.steps = int(words.pop(0))
         self.alarm = words.pop(0) == 'true'
-        # self.alarm = int(words.pop(0)) == 0
         if self.alarm:
             self.is_referenced = False

--- a/field_friend/hardware/y_axis_stepper_hardware.py
+++ b/field_friend/hardware/y_axis_stepper_hardware.py
@@ -33,6 +33,7 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
         lizard_code = remove_indentation(f'''
             {name}_motor = {expander.name + "." if motor_on_expander and expander else ""}StepperMotor({step_pin}, {dir_pin})
             {name}_alarm = {expander.name + "." if motor_on_expander and expander else ""}Input({alarm_pin})
+            {name}_alarm.inverted = true 
             {name}_end_l = {expander.name + "." if end_stops_on_expander and expander else ""}Input({end_l_pin})
             {name}_end_l.inverted = {str(end_stops_inverted).lower()}
             {name}_end_r = {expander.name + "." if end_stops_on_expander and expander else ""}Input({end_r_pin})
@@ -68,8 +69,10 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
         try:
             await super().move_to(position, speed)
         except RuntimeError as error:
-            self.log.info(f'could not move yaxis to {position} because of {error}')
-            raise Exception(f'could not move yaxis to {position} because of {error}')
+            self.log.info(
+                f'could not move yaxis to {position} because of {error}')
+            raise Exception(
+                f'could not move yaxis to {position} because of {error}')
         steps = self.compute_steps(position)
         await self.robot_brain.send(f'{self.name}.position({steps}, {speed}, 250000);')
         await rosys.sleep(0.2)
@@ -92,7 +95,8 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
             # if in end l stop, move out first
             if self.end_l:
                 self.log.info('already in end_l moving out of end_l stop')
-                velocity = self.reference_speed * (1 if self.reversed_direction else -1)
+                velocity = self.reference_speed * \
+                    (1 if self.reversed_direction else -1)
                 await self.robot_brain.send(f'{self.name}.speed({velocity});')
                 while self.end_l:
                     await rosys.sleep(0.2)
@@ -101,7 +105,8 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
             # if to end r stop if not already there
             if not self.end_r:
                 self.log.info('moving to end_r stop')
-                velocity = self.reference_speed * (1 if self.reversed_direction else -1)
+                velocity = self.reference_speed * \
+                    (1 if self.reversed_direction else -1)
                 await self.robot_brain.send(f'{self.name}.speed({velocity});')
                 while not self.end_r:
                     await rosys.sleep(0.2)
@@ -109,7 +114,8 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
 
             # move out of end r stop
             self.log.info('moving out of end_r stop')
-            velocity = self.reference_speed * (-1 if self.reversed_direction else 1)
+            velocity = self.reference_speed * \
+                (-1 if self.reversed_direction else 1)
             await self.robot_brain.send(f'{self.name}.speed({velocity});')
             while self.end_r:
                 await rosys.sleep(0.2)
@@ -117,14 +123,16 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
 
             # move slowly to end r stop
             self.log.info('moving slowly to end_r stop')
-            velocity = round(self.reference_speed / 2) * (1 if self.reversed_direction else -1)
+            velocity = round(self.reference_speed / 2) * \
+                (1 if self.reversed_direction else -1)
             await self.robot_brain.send(f'{self.name}.speed({velocity});')
             while not self.end_r:
                 await rosys.sleep(0.2)
 
             # move slowly out of end r stop
             self.log.info('moving slowly out of end_r stop')
-            velocity = round(self.reference_speed / 2) * (-1 if self.reversed_direction else 1)
+            velocity = round(self.reference_speed / 2) * \
+                (-1 if self.reversed_direction else 1)
             await self.robot_brain.send(f'{self.name}.speed({velocity});')
             while self.end_r:
                 await rosys.sleep(0.2)
@@ -150,5 +158,6 @@ class YAxisStepperHardware(YAxis, rosys.hardware.ModuleHardware):
         self.idle = words.pop(0) == 'true'
         self.steps = int(words.pop(0))
         self.alarm = words.pop(0) == 'true'
+        # self.alarm = int(words.pop(0)) == 0
         if self.alarm:
             self.is_referenced = False

--- a/field_friend/interface/components/camera_card.py
+++ b/field_friend/interface/components/camera_card.py
@@ -1,6 +1,6 @@
 import colorsys
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import rosys
@@ -8,39 +8,52 @@ from nicegui import ui
 from nicegui.events import MouseEventArguments, ValueChangeEventArguments
 from rosys.geometry import Point
 
+from field_friend.automations.implements.weeding_implement import WeedingImplement
+
 from ...automations import PlantLocator, Puncher
 from ...hardware import FieldFriend, FlashlightPWM, FlashlightPWMV2, Tornado, ZAxis
 from .calibration_dialog import calibration_dialog
 
+if TYPE_CHECKING:
+    from system import System
+
 
 class camera_card:
 
-    def __init__(self,
-                 camera_provider: rosys.vision.CameraProvider,
-                 automator: rosys.automation.Automator,
-                 detector: rosys.vision.Detector,
-                 plant_locator: PlantLocator,
-                 field_friend: FieldFriend,
-                 puncher: Optional[Puncher] = None,
-                 *,
-                 shrink_factor: int = 1) -> None:
+    def __init__(self, system: 'System') -> None:
         self.log = logging.getLogger('field_friend.camera_card')
+        self.automator = system.automator
+        self.camera_provider = system.usb_camera_provider
+        self.detector = system.detector
+        self.field_friend = system.field_friend
+        self.odometer = system.odometer
+        self.plant_locator = system.plant_locator
+        self.plant_provider = system.plant_provider
+        self.puncher = system.puncher
+        self.system = system
+        self.punching_enabled: bool = False
+        self.shrink_factor: float = 2.0
+        self.show_weeds_to_handle: bool = False
         self.camera: Optional[rosys.vision.CalibratableCamera] = None
-        self.camera_provider = camera_provider
-        self.automator = automator
-        self.detector = detector
-        self.plant_locator = plant_locator
+        self.camera_provider = system.usb_camera_provider
+        self.automator = system.automator
+        self.detector = system.detector
+        self.plant_locator = system.plant_locator
         self.punching_enabled = False
-        self.puncher = puncher
-        self.field_friend = field_friend
-        self.shrink_factor = shrink_factor
+        self.puncher = system.puncher
+        self.field_friend = system.field_friend
+        self.odometer = system.odometer
+        self.shrink_factor = 2
         self.image_view: Optional[ui.interactive_image] = None
-        self.calibration_dialog = calibration_dialog(camera_provider)
+        self.calibration_dialog = calibration_dialog(self.camera_provider)
+        self.plant_provider = system.plant_provider
+        self.system = system
         self.camera_card = ui.card()
+        self.show_weeds_to_handle = False
         with self.camera_card.tight().classes('w-full'):
             ui.label('no camera available').classes('text-center')
             ui.image('assets/field_friend.webp').classes('w-full')
-        ui.timer(0.2, self.update_content)
+        ui.timer(0.2 if system.is_real else 0.05, self.update_content)
 
     def use_camera(self, cam: rosys.vision.CalibratableCamera) -> None:
         self.camera = cam
@@ -82,6 +95,9 @@ class camera_card:
                         self.show_mapping_checkbox = ui.checkbox('Mapping', on_change=self.show_mapping) \
                             .tooltip('Show the mapping between camera and world coordinates')
                     with ui.menu_item():
+                        ui.checkbox('Show weeds to handle').bind_value_to(self, 'show_weeds_to_handle') \
+                            .tooltip('Show the mapping between camera and world coordinates')
+                    with ui.menu_item():
                         ui.button('calibrate', on_click=self.calibrate) \
                             .props('icon=straighten outline').tooltip('Calibrate camera')
                     # TODO: ist das hier ein todo?: Add a button to save the last captured image
@@ -100,7 +116,7 @@ class camera_card:
     def update_content(self) -> None:
         cameras = list(self.camera_provider.cameras.values())
         active_camera = next((camera for camera in cameras if camera.is_connected), None)
-        if not active_camera:
+        if active_camera is None:
             if self.camera:
                 self.camera = None
                 self.camera_card.clear()
@@ -111,13 +127,19 @@ class camera_card:
         if self.camera is None or self.camera != active_camera:
             self.use_camera(active_camera)
         if self.shrink_factor > 1:
-            url = f'{self.camera.get_latest_image_url()}?shrink={self.shrink_factor}'
+            url = f'{active_camera.get_latest_image_url()}?shrink={self.shrink_factor}'
         else:
-            url = self.camera.get_latest_image_url()
+            url = active_camera.get_latest_image_url()
+        if self.image_view is None or self.camera.calibration is None:
+            return
         self.image_view.set_source(url)
-        image = self.camera.latest_detected_image
+        image = active_camera.latest_detected_image
+        svg = ''
         if image and image.detections:
-            self.image_view.set_content(self.to_svg(image.detections))
+            svg += self.to_svg(image.detections)
+        svg += self.build_svg_for_plant_provider()
+        svg += self.build_svg_for_implement()
+        self.image_view.set_content(svg)
 
     def on_mouse_move(self, e: MouseEventArguments):
         if self.camera is None:
@@ -148,6 +170,7 @@ class camera_card:
             self.debug_position.set_text('')
 
     async def calibrate(self) -> None:
+        assert self.camera is not None
         result = await self.calibration_dialog.edit(self.camera)
         if result:
             self.show_mapping_checkbox.value = True
@@ -174,29 +197,52 @@ class camera_card:
         cross_size = 20
         for point in detections.points:
             if point.category_name in self.plant_locator.crop_category_names:
-                if point.confidence > self.plant_locator.minimum_crop_confidence:
-                    svg += f'<circle cx="{point.x / self.shrink_factor}" cy="{point.y / self.shrink_factor}" r="18" stroke-width="8" stroke="green" fill="none" />'
-                    svg += f'<text x="{point.x / self.shrink_factor-30}" y="{point.y / self.shrink_factor+30}" font-size="20" fill="green">Crop</text>'
-                else:
-                    svg += f'<circle cx="{point.x / self.shrink_factor}" cy="{point.y / self.shrink_factor}" r="18" stroke-width="8" stroke="orange" fill="none" />'
-                    svg += f'<text x="{point.x / self.shrink_factor-30}" y="{point.y / self.shrink_factor+30}" font-size="20" fill="orange">{point.category_name}</text>'
+                svg += f'<circle cx="{int(point.x / self.shrink_factor)}" cy="{int(point.y / self.shrink_factor)}" r="18" stroke-width="8" stroke="green" fill="none" />'
             elif point.category_name in self.plant_locator.weed_category_names:
-                if point.confidence > self.plant_locator.minimum_weed_confidence:
-                    svg += f'''
-                            <line x1="{point.x / self.shrink_factor - cross_size}" y1="{point.y / self.shrink_factor}" x2="{point.x / self.shrink_factor + cross_size}" y2="{point.y / self.shrink_factor}" stroke="red" stroke-width="8" 
-                                transform="rotate(45, {point.x / self.shrink_factor}, {point.y / self.shrink_factor})"/>
-                            <line x1="{point.x / self.shrink_factor}" y1="{point.y / self.shrink_factor - cross_size}" x2="{point.x / self.shrink_factor}" y2="{point.y / self.shrink_factor + cross_size}" stroke="red" stroke-width="8" 
-                                transform="rotate(45, {point.x / self.shrink_factor}, {point.y / self.shrink_factor})"/>
-                            <text x="{point.x / self.shrink_factor-30}" y="{point.y / self.shrink_factor+30}" font-size="20" fill="red">Weed</text>
-                    '''
-                else:
-                    svg += f'''
-                            <line x1="{point.x / self.shrink_factor - cross_size}" y1="{point.y / self.shrink_factor}" x2="{point.x / self.shrink_factor + cross_size}" y2="{point.y / self.shrink_factor}" stroke="yellow" stroke-width="8" 
-                                transform="rotate(45, {point.x / self.shrink_factor}, {point.y / self.shrink_factor})"/>
-                            <line x1="{point.x / self.shrink_factor}" y1="{point.y / self.shrink_factor - cross_size}" x2="{point.x / self.shrink_factor}" y2="{point.y / self.shrink_factor + cross_size}" stroke="yellow" stroke-width="8" 
-                                transform="rotate(45, {point.x / self.shrink_factor}, {point.y / self.shrink_factor})"/>
-                            <text x="{point.x / self.shrink_factor-30}" y="{point.y / self.shrink_factor+30}" font-size="20" fill="yellow">Weed</text>
-                    '''
+                svg += f'''<line x1="{int(point.x / self.shrink_factor) - cross_size}" y1="{int(point.y / self.shrink_factor)}" x2="{int(point.x / self.shrink_factor) + cross_size}" y2="{int(point.y / self.shrink_factor)}" stroke="red" stroke-width="8" 
+    transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/><line x1="{int(point.x / self.shrink_factor)}" y1="{int(point.y / self.shrink_factor) - cross_size}" x2="{int(point.x / self.shrink_factor)}" y2="{int(point.y / self.shrink_factor) + cross_size}" stroke="red" stroke-width="8" 
+    transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/>'''
+        return svg
+
+    def build_svg_for_implement(self) -> str:
+        if not isinstance(self.system.current_implement, WeedingImplement) or self.camera is None or self.camera.calibration is None:
+            return ''
+        if self.system.is_real:
+            return ''  # NOTE: until https://github.com/zauberzeug/rosys/discussions/130 is resolved and integrated real robots will have problems with reverse projection
+        tool_3d = self.odometer.prediction.point_3d() + \
+            rosys.geometry.Point3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.position, z=0)
+        tool_2d = self.camera.calibration.project_to_image(tool_3d) / self.shrink_factor
+        svg = f'<circle cx="{int(tool_2d.x)}" cy="{int(tool_2d.y)}" r="10" fill="black"/>'
+        min_tool_3d = self.odometer.prediction.point_3d() + \
+            rosys.geometry.Point3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.min_position, z=0)
+        min_tool_2d = self.camera.calibration.project_to_image(min_tool_3d) / self.shrink_factor
+        max_tool_3d = self.odometer.prediction.point_3d() + \
+            rosys.geometry.Point3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.max_position, z=0)
+        max_tool_2d = self.camera.calibration.project_to_image(max_tool_3d) / self.shrink_factor
+        svg += f'<line x1="{int(min_tool_2d.x)}" y1="{int(min_tool_2d.y)}" x2="{int(max_tool_2d.x)}" y2="{int(max_tool_2d.y)}" stroke="black" stroke-width="2" />'
+        if self.show_weeds_to_handle:
+            for i, plant in enumerate(self.system.current_implement.weeds_to_handle.values()):
+                position_3d = self.odometer.prediction.point_3d() + rosys.geometry.Point3d(x=plant.x, y=plant.y, z=0)
+                screen = self.camera.calibration.project_to_image(position_3d)
+                if screen is not None:
+                    svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="6" stroke="blue" fill="transparent" stroke-width="2" />'
+                    svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+4}" fill="blue" font-size="9" text-anchor="middle">{i}</text>'
+        return svg
+
+    def build_svg_for_plant_provider(self) -> str:
+        if self.camera is None or self.camera.calibration is None:
+            return ''
+        if self.system.is_real:
+            return ''  # NOTE: until https://github.com/zauberzeug/rosys/discussions/130 is resolved and integrated real robots will have problems with reverse projection
+        position = rosys.geometry.Point(x=self.camera.calibration.extrinsics.translation[0],
+                                        y=self.camera.calibration.extrinsics.translation[1])
+        svg = ''
+        for plant in self.plant_provider.get_relevant_weeds(position):
+            position_3d = rosys.geometry.Point3d(x=plant.position.x, y=plant.position.y, z=0)
+            screen = self.camera.calibration.project_to_image(position_3d)
+            if screen is not None:
+                svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" fill="white" />'
+                svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+16}" fill="black" font-size="9" text-anchor="middle">{plant.id[:4]}</text>'
         return svg
 
     # async def save_last_image(self) -> None:

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -151,13 +151,12 @@ class FieldCreator:
         assert self.first_row_start is not None
         assert self.first_row_end is not None
         assert self.last_row_end is not None
-        self.field.reference = self.first_row_start
         distance = self.first_row_end.distance(self.last_row_end)
         number_of_rows = distance / (self.row_spacing) + 1
         # get AB line
-        a = self.first_row_start.cartesian(self.field.reference)
-        b = self.first_row_end.cartesian(self.field.reference)
-        c = self.last_row_end.cartesian(self.field.reference)
+        a = self.first_row_start.cartesian()
+        b = self.first_row_end.cartesian()
+        c = self.last_row_end.cartesian()
         ab = a.direction(b)
         bc = b.direction(c)
         d = a.polar(distance, bc)
@@ -165,14 +164,14 @@ class FieldCreator:
             start = a.polar(i * self.row_spacing, bc)
             end = b.polar(i * self.row_spacing, bc)
             self.field.rows.append(Row(id=str(uuid4()), name=f'Row #{len(self.field.rows)}',
-                                       points=[self.field.reference.shifted(start),
-                                               self.field.reference.shifted(end)]
+                                       points=[self.first_row_start.shifted(start),
+                                               self.first_row_start.shifted(end)]
                                        ))
         bottom_left = a.polar(-self.padding_bottom, ab).polar(-self.padding, bc)
         top_left = b.polar(self.padding, ab).polar(-self.padding, bc)
         top_right = c.polar(self.padding, ab).polar(self.padding, bc)
         bottom_right = d.polar(-self.padding_bottom, ab).polar(self.padding, bc)
-        self.field.points = [self.field.reference.shifted(p) for p in [bottom_left, top_left, top_right, bottom_right]]
+        self.field.points = [self.first_row_start.shifted(p) for p in [bottom_left, top_left, top_right, bottom_right]]
         return 1 - number_of_rows % 1 < 0.1
 
     def _apply(self) -> None:

--- a/field_friend/interface/components/field_object.py
+++ b/field_friend/interface/components/field_object.py
@@ -1,7 +1,8 @@
 import numpy as np
 from nicegui.elements.scene_objects import Box, Curve, Cylinder, Extrusion, Group
 from rosys.geometry import Spline
-from ...automations import FieldProvider, Field
+
+from ...automations import Field, FieldProvider
 
 
 class field_object(Group):
@@ -42,7 +43,7 @@ class field_object(Group):
         [obj.delete() for obj in list(self.scene.objects.values()) if obj.name and obj.name.startswith('field_')]
         [obj.delete() for obj in list(self.scene.objects.values()) if obj.name and obj.name.startswith('obstacle_')]
         [obj.delete() for obj in list(self.scene.objects.values()) if obj.name and obj.name.startswith('row_')]
-        if active_field and active_field.reference is not None:
+        if active_field:
             field = active_field
             outline = [[point.x, point.y] for point in field.outline]
             if len(outline) > 1:  # Make sure there are at least two points to form a segment
@@ -51,17 +52,15 @@ class field_object(Group):
                     end = outline[(i + 1) % len(outline)]  # Loop back to the first point
                     self.create_fence(start, end)
 
-            if not field.reference:
-                return
             for obstacle in field.obstacles:
-                outline = [[point.x, point.y] for point in obstacle.cartesian(field.reference)]
+                outline = [[point.x, point.y] for point in obstacle.cartesian()]
                 Extrusion(outline, 0.1).with_name(f'obstacle_{obstacle.id}').material('#B80F0A')
 
             for row in field.rows:
                 if len(row.points) == 1:
                     continue
                 else:
-                    row_points = row.cartesian(field.reference)
+                    row_points = row.cartesian()
                     for i in range(len(row_points) - 1):
                         spline = Spline.from_points(row_points[i], row_points[i + 1])
                         Curve(

--- a/field_friend/interface/components/field_planner.py
+++ b/field_friend/interface/components/field_planner.py
@@ -1,11 +1,9 @@
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict
+from typing import TYPE_CHECKING, Literal, Optional, TypedDict
 
-import rosys
 from nicegui import events, ui
 
-from ...automations import Field, FieldObstacle, FieldProvider, Row
-from ...localization import Gnss
+from ...automations import Field, FieldObstacle, Row
 from .field_creator import FieldCreator
 from .leaflet_map import leaflet_map
 
@@ -40,10 +38,13 @@ class field_planner:
                         .classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
                     ui.button("Field Wizard", on_click=lambda: FieldCreator(system)).tooltip("Build a field with rows in a few simple steps") \
                         .classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
-                    ui.button("Clear fields", on_click=self.field_provider.clear_fields).props("outline color=warning") \
-                        .tooltip("Delete all fields").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
                 with ui.row().style("width: 100%;"):
                     self.show_field_table()
+                with ui.row():
+                    ui.button("Clear fields", on_click=self.field_provider.clear_fields).props("outline color=warning") \
+                        .tooltip("Delete all fields").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
+                    ui.button("Update reference", on_click=self.field_provider.update_reference).props("outline color=warning") \
+                        .tooltip("Set current position as geo reference and restart the system").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
             self.show_field_settings()
             self.show_object_settings()
             self.field_provider.FIELDS_CHANGED.register_ui(self.refresh_ui)

--- a/field_friend/interface/components/leaflet_map.py
+++ b/field_friend/interface/components/leaflet_map.py
@@ -80,8 +80,6 @@ class leaflet_map:
                 else:
                     with ui.dialog() as simulated_marker_dialog, ui.card():
                         ui.label('You are currently working in a simulation. What does the placed point represent?')
-                        ui.button('simulated roboter reference point',
-                                  on_click=lambda: self.set_simulated_reference(latlon, simulated_marker_dialog))
                         ui.button('as point for the current object',
                                   on_click=lambda: self.add_point_active_object(latlon, simulated_marker_dialog))
                         ui.button('Close', on_click=lambda: self.abort_point_drawing(simulated_marker_dialog))
@@ -111,19 +109,6 @@ class leaflet_map:
             .bind_enabled_from(self, 'active_field') \
             .props('icon=polyline dense flat') \
             .tooltip('center map on field boundaries').classes('ml-0')
-
-    def set_simulated_reference(self, latlon, dialog):
-        dialog.close()
-        self.m.remove_layer(self.drawn_marker)
-        self.gnss.reference = GeoPoint.from_list(latlon)
-        self.gnss.ROBOT_GNSS_POSITION_CHANGED.emit()
-        self.gnss.ROBOT_POSE_LOCATED.emit(rosys.geometry.Pose(
-            x=0.000,
-            y=0.000,
-            yaw=0.0,
-            time=0
-        ))
-        ui.notify(f'Robot reference has been set to {latlon[0]}, {latlon[1]}')
 
     def abort_point_drawing(self, dialog) -> None:
         if self.drawn_marker is not None:

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -1,13 +1,9 @@
-
-import asyncio
 import logging
 from typing import TYPE_CHECKING
 
 from nicegui import app, events, ui
 
-from .field_creator import FieldCreator
 from .key_controls import KeyControls
-from .punch_dialog import PunchDialog
 
 if TYPE_CHECKING:
     from field_friend.system import System
@@ -55,22 +51,6 @@ class operation:
                 .tooltip('Select the implement to work with') \
                 .bind_value_from(self.system, 'current_implement', lambda i: i.name)
             self.implement_selection.value = self.system.current_implement.name
-
-        self.system.puncher.POSSIBLE_PUNCH.register_ui(self.can_punch)
-        self.punch_dialog = PunchDialog(self.system)
-
-    async def can_punch(self, plant_id: str) -> None:
-        self.punch_dialog.target_plant = self.system.plant_provider.get_plant_by_id(plant_id)
-        result: str | None = None
-        try:
-            result = await asyncio.wait_for(self.punch_dialog, timeout=self.punch_dialog.timeout)
-        except asyncio.TimeoutError:
-            self.punch_dialog.close()
-            result = None
-        if result == 'Yes':
-            self.system.puncher.punch_allowed = 'allowed'
-        elif result is None or result == 'No' or result == 'Cancel':
-            self.system.puncher.punch_allowed = 'not_allowed'
 
     def handle_implement_changed(self, e: events.ValueChangeEventArguments) -> None:
         if self.system.current_implement.name != e.value:

--- a/field_friend/interface/components/status_dev.py
+++ b/field_friend/interface/components/status_dev.py
@@ -5,8 +5,17 @@ import psutil
 import rosys
 from nicegui import ui
 
-from ...hardware import (ChainAxis, FieldFriend, FieldFriendHardware, FlashlightPWMHardware, FlashlightPWMHardwareV2,
-                         Tornado, YAxis, ZAxis)
+from ... import localization
+from ...hardware import (
+    ChainAxis,
+    FieldFriend,
+    FieldFriendHardware,
+    FlashlightPWMHardware,
+    FlashlightPWMHardwareV2,
+    Tornado,
+    YAxis,
+    ZAxis,
+)
 
 if TYPE_CHECKING:
     from field_friend.system import System
@@ -298,7 +307,7 @@ def status_dev_page(robot: FieldFriend, system: 'System'):
             if robot.wheels.odrive_version == 4:
                 l0_status.text = 'cant read status update odrive to version 0.5.6'
         gnss_device_label.text = 'No connection' if system.gnss.device is None else 'Connected'
-        reference_position_label.text = 'No reference' if system.gnss.reference is None else 'Set'
+        reference_position_label.text = 'No reference' if localization.reference is None else 'Set'
         gnss_label.text = str(system.gnss.current.location) if system.gnss.current is not None else 'No position'
         heading_label.text = f'{system.gnss.current.heading:.2f}° {direction_flag}' if system.gnss.current is not None and system.gnss.current.heading is not None else 'No heading'
         rtk_fix_label.text = f'gps_qual: {system.gnss.current.gps_qual}, mode: {system.gnss.current.mode}' if system.gnss.current is not None else 'No fix'

--- a/field_friend/interface/components/status_drawer.py
+++ b/field_friend/interface/components/status_drawer.py
@@ -1,3 +1,4 @@
+from ... import localization
 from typing import TYPE_CHECKING
 
 import rosys
@@ -26,7 +27,6 @@ def status_drawer(system: 'System', robot: FieldFriend, gnss: Gnss, odometer: ro
                     ui.menu_item('Restart RoSys', on_click=system.restart)
                     if system.is_real:
                         ui.menu_item('Restart Lizard', on_click=system.field_friend.robot_brain.restart)
-                    ui.menu_item('Clear GNSS reference', on_click=system.gnss.clear_reference)
 
         ui.label('System Status').classes('text-xl')
 
@@ -232,7 +232,7 @@ def status_drawer(system: 'System', robot: FieldFriend, gnss: Gnss, odometer: ro
                 #         kpi_punches_label.text = system.kpi_provider.current_weeding_kpis.punches
 
             gnss_device_label.text = 'No connection' if gnss.device is None else 'Connected'
-            reference_position_label.text = 'No reference' if gnss.reference is None else 'Set'
+            reference_position_label.text = 'No reference' if localization.reference is None else 'Set'
             gnss_label.text = str(system.gnss.current.location) if system.gnss.current is not None else 'No position'
             heading_label.text = f'{system.gnss.current.heading:.2f}° {direction_flag}' if system.gnss.current is not None and system.gnss.current.heading is not None else 'No heading'
             rtk_fix_label.text = f'gps_qual: {system.gnss.current.gps_qual}, mode: {system.gnss.current.mode}' if system.gnss.current is not None else 'No fix'

--- a/field_friend/interface/pages/main_page.py
+++ b/field_friend/interface/pages/main_page.py
@@ -34,12 +34,7 @@ class main_page():
             with ui.row().classes('h-full ml-2 m-2').style('width: calc(100% - 1rem)'):
                 operation(self.system)
                 with ui.column().classes('h-full').style('width: calc(45% - 2rem); flex-wrap: nowrap;'):
-                    camera_card(self.system.usb_camera_provider,
-                                self.system.automator,
-                                self.system.detector,
-                                self.system.plant_locator,
-                                self.system.field_friend,
-                                self.system.puncher)
+                    camera_card(self.system)
                     robot_scene(self.system, self.system.field_navigation.field)
                     with ui.row().style("margin: 1rem; width: calc(100% - 2rem);"):
                         with ui.column():

--- a/field_friend/localization/__init__.py
+++ b/field_friend/localization/__init__.py
@@ -2,3 +2,6 @@ from .geo_point import GeoPoint, GeoPointCollection
 from .gnss import Gnss, GNSSRecord
 from .gnss_hardware import GnssHardware
 from .gnss_simulation import GnssSimulation
+
+
+reference: GeoPoint = GeoPoint(lat=0, long=0)

--- a/field_friend/localization/geo_point.py
+++ b/field_friend/localization/geo_point.py
@@ -8,6 +8,8 @@ import rosys
 import shapely
 from geographiclib.geodesic import Geodesic
 
+from .. import localization
+
 
 @dataclass(slots=True, kw_only=True)
 class GeoPoint:
@@ -26,15 +28,12 @@ class GeoPoint:
         geodetic_measurement = Geodesic.WGS84.Inverse(self.lat, self.long, other.lat, other.long)
         return geodetic_measurement['s12']
 
-    def cartesian(self, reference: GeoPoint) -> rosys.geometry.Point:
-        """Calculate the cartesian coordinates of this point relative to a reference point.
+    def cartesian(self) -> rosys.geometry.Point:
+        """Calculate the cartesian coordinates of this point relative to the reference point.
 
         This method uses the geodesic distance and azimuth angle between the reference point and
         the current point to calculate the Cartesian coordinates.
         The azimuth angle is measured clockwise from the north direction, and the resulting Cartesian coordinates have the x-axis to north and y-axis to west.
-
-        Parameters:
-        reference (GeoPoint): The reference GeoPoint to which the Cartesian coordinates are relative.
 
         Returns:
         rosys.geometry.Point: A Point object representing the Cartesian coordinates (x, y) 
@@ -42,7 +41,7 @@ class GeoPoint:
                             - x is the eastward distance in meters,
                             - y is the northward distance in meters.
         """
-        r = Geodesic.WGS84.Inverse(reference.lat, reference.long, self.lat, self.long)
+        r = Geodesic.WGS84.Inverse(localization.reference.lat, localization.reference.long, self.lat, self.long)
         s = r['s12']
         a = -np.deg2rad(r['azi1'])
         x = s * np.cos(a)
@@ -76,10 +75,10 @@ class GeoPointCollection:
     name: str
     points: list[GeoPoint] = field(default_factory=list)
 
-    def cartesian(self, reference: GeoPoint) -> list[rosys.geometry.Point]:
+    def cartesian(self) -> list[rosys.geometry.Point]:
         cartesian_points = []
         for point in self.points:
-            cartesian_points.append(point.cartesian(reference))
+            cartesian_points.append(point.cartesian())
         return cartesian_points
 
     @property

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -4,12 +4,12 @@ import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Optional, Protocol
+from typing import Optional
 
 import numpy as np
 import rosys
-import serial
 
+from .. import localization
 from .geo_point import GeoPoint
 from .point_transformation import get_new_position
 
@@ -47,41 +47,15 @@ class Gnss(ABC):
 
         self.current: Optional[GNSSRecord] = None
         self.device: str | None = None
-        self._reference: Optional[GeoPoint] = None
         self.antenna_offset = antenna_offset
 
         self.needs_backup = False
         rosys.on_repeat(self.update, 0.01)
         rosys.on_repeat(self.try_connection, 3.0)
 
-    @property
-    def reference(self) -> Optional[GeoPoint]:
-        return self._reference
-
-    @reference.setter
-    def reference(self, reference: GeoPoint) -> None:
-        assert reference is not None
-        if self._reference is not None:
-            relative_location_of_new_reference = reference.cartesian(self._reference)
-            new_position = self.odometer.prediction.point + relative_location_of_new_reference
-            self.odometer.history.clear()
-            self.odometer.prediction = rosys.geometry.Pose(x=new_position.x, y=new_position.y,
-                                                           yaw=self.odometer.prediction.yaw,
-                                                           time=rosys.time())
-        self._reference = reference
-
     @abstractmethod
     async def try_connection(self) -> None:
         pass
-
-    def clear_reference(self) -> None:
-        self.reference = None
-
-    def distance(self, point: GeoPoint) -> Optional[float]:
-        """Compute the distance between the reference point and the given point in meters"""
-        if self.reference is None:
-            return None
-        return point.distance(point)
 
     async def update(self) -> None:
         previous = deepcopy(self.current)
@@ -116,9 +90,9 @@ class Gnss(ABC):
 
     def _on_rtk_fix(self) -> None:
         assert self.current is not None
-        if self.reference is None:
+        if localization.reference.lat == 0 and localization.reference.long == 0:
             self.log.info(f'GNSS reference set to {self.current.location}')
-            self.reference = deepcopy(self.current.location)
+            localization.reference = deepcopy(self.current.location)
         if self.current.heading is not None:
             yaw = np.deg2rad(-self.current.heading)
         else:
@@ -126,7 +100,7 @@ class Gnss(ABC):
             yaw = self.odometer.get_pose(time=self.current.timestamp).yaw
         # correct the gnss coordinate by antenna offset
         self.current.location = get_new_position(self.current.location, self.antenna_offset, yaw+np.pi/2)
-        cartesian_coordinates = self.current.location.cartesian(self.reference)
+        cartesian_coordinates = self.current.location.cartesian()
         distance = self.odometer.prediction.point.distance(cartesian_coordinates)
         if distance > 1:
             self.log.warning(f'GNSS distance to prediction too high: {distance:.2f}m!!')

--- a/field_friend/localization/gnss_simulation.py
+++ b/field_friend/localization/gnss_simulation.py
@@ -2,14 +2,16 @@ from typing import Optional
 
 import rosys
 
+from .. import localization
 from .geo_point import GeoPoint
 from .gnss import Gnss, GNSSRecord
 
 
 class GnssSimulation(Gnss):
 
-    def __init__(self, odometer: rosys.driving.Odometer) -> None:
+    def __init__(self, odometer: rosys.driving.Odometer, wheels: rosys.hardware.WheelsSimulation) -> None:
         super().__init__(odometer, 0.0)
+        self.wheels = wheels
         self.allow_connection = True
         self.gps_quality = 4
 
@@ -18,9 +20,11 @@ class GnssSimulation(Gnss):
             self.device = 'simulation'
 
     async def _create_new_record(self) -> Optional[GNSSRecord]:
-        pose = self.odometer.prediction
-        reference = self.reference if self.reference else GeoPoint(lat=51.983159, long=7.434212)
-        new_position = reference.shifted(pose.point)
+        pose = self.wheels.pose
+        if localization.reference.lat == 0 and localization.reference.long == 0:
+            new_position = GeoPoint(lat=51.983159, long=7.434212)
+        else:
+            new_position = localization.reference.shifted(pose.point)
         record = GNSSRecord(timestamp=pose.time, location=new_position)
         record.mode = "simulation"  # TODO check for possible values and replace "simulation"
         record.gps_qual = self.gps_quality

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -6,18 +6,43 @@ import numpy as np
 import psutil
 import rosys
 
-from field_friend.hardware import FieldFriend, FieldFriendHardware, FieldFriendSimulation
-from field_friend.localization.gnss_hardware import GnssHardware
-from field_friend.localization.gnss_simulation import GnssSimulation
-from field_friend.vision import CalibratableUsbCameraProvider, CameraConfigurator, SimulatedCam, SimulatedCamProvider
-
-from .automations import (AutomationWatcher, BatteryWatcher, FieldProvider, KpiProvider, PathProvider, PathRecorder,
-                          PlantLocator, PlantProvider, Puncher)
-from .automations.implements import ChopAndScrew, Implement, Recorder, Tornado, WeedingScrew
-from .automations.navigation import (CoverageNavigation, FollowCropsNavigation, Navigation, RowsOnFieldNavigation,
-                                     StraightLineNavigation)
+from . import localization
+from .automations import (
+    AutomationWatcher,
+    BatteryWatcher,
+    FieldProvider,
+    KpiProvider,
+    PathProvider,
+    PlantLocator,
+    PlantProvider,
+    Puncher,
+)
+from .automations.implements import (
+    ChopAndScrew,
+    Implement,
+    Recorder,
+    Tornado,
+    WeedingScrew,
+)
+from .automations.navigation import (
+    CoverageNavigation,
+    FollowCropsNavigation,
+    Navigation,
+    RowsOnFieldNavigation,
+    StraightLineNavigation,
+)
+from .hardware import FieldFriend, FieldFriendHardware, FieldFriendSimulation
 from .interface.components.info import Info
 from .kpi_generator import generate_kpis
+from .localization.geo_point import GeoPoint
+from .localization.gnss_hardware import GnssHardware
+from .localization.gnss_simulation import GnssSimulation
+from .vision import (
+    CalibratableUsbCameraProvider,
+    CameraConfigurator,
+    SimulatedCam,
+    SimulatedCamProvider,
+)
 
 
 class System(rosys.persistence.PersistentModule):
@@ -61,7 +86,8 @@ class System(rosys.persistence.PersistentModule):
             assert isinstance(self.field_friend, FieldFriendHardware)
             self.gnss = GnssHardware(self.odometer, self.field_friend.ANTENNA_OFFSET)
         else:
-            self.gnss = GnssSimulation(self.odometer)
+            assert isinstance(self.field_friend.wheels, rosys.hardware.WheelsSimulation)
+            self.gnss = GnssSimulation(self.odometer, self.field_friend.wheels)
         self.gnss.ROBOT_POSE_LOCATED.register(self.odometer.handle_detection)
         self.driver = rosys.driving.Driver(self.field_friend.wheels, self.odometer)
         self.driver.parameters.linear_speed_limit = 0.3
@@ -131,8 +157,9 @@ class System(rosys.persistence.PersistentModule):
             case 'weed_screw':
                 implements.append(WeedingScrew(self))
             case 'dual_mechanism':
-                implements.append(WeedingScrew(self))
-                implements.append(ChopAndScrew(self))
+                # implements.append(WeedingScrew(self))
+                # implements.append(ChopAndScrew(self))
+                self.log.error('Dual mechanism not implemented')
             case 'none':
                 implements.append(WeedingScrew(self))
             case _:
@@ -160,6 +187,8 @@ class System(rosys.persistence.PersistentModule):
         return {
             'navigation': self.current_navigation.name,
             'implement': self.current_implement.name,
+            'reference_lat': localization.reference.lat,
+            'reference_long': localization.reference.long,
         }
 
     def restore(self, data: dict[str, Any]) -> None:
@@ -169,6 +198,9 @@ class System(rosys.persistence.PersistentModule):
         navigation = self.navigation_strategies.get(data.get('navigation', None), None)
         if navigation is not None:
             self.current_navigation = navigation
+        lat = data.get('reference_lat', 0)
+        long = data.get('reference_long', 0)
+        localization.reference = GeoPoint(lat=lat, long=long)
 
     @property
     def current_implement(self) -> Implement:
@@ -201,7 +233,9 @@ class System(rosys.persistence.PersistentModule):
                                                 x=0.4, z=0.4,
                                                 roll=np.deg2rad(360-150),
                                                 pitch=np.deg2rad(0),
-                                                yaw=np.deg2rad(90))
+                                                yaw=np.deg2rad(90),
+                                                color='#cccccc',
+                                                )
         self.usb_camera_provider.add_camera(camera)
         # TODO rework this when RoSys supports multiple extrinsics (see https://github.com/zauberzeug/rosys/discussions/130)
         self.odometer.ROBOT_MOVED.register(lambda: camera.update_calibration(self.odometer.prediction))
@@ -212,5 +246,8 @@ class System(rosys.persistence.PersistentModule):
         return float(temp) / 1000.0  # Convert from milli °C to °C
 
     def log_status(self):
-        msg = f'cpu: {psutil.cpu_percent():.0f}%  mem: {psutil.virtual_memory().percent:.0f}% temp: {self.get_jetson_cpu_temperature():.1f}°C'
+        msg = f'cpu: {psutil.cpu_percent():.0f}%  '
+        msg += f'mem: {psutil.virtual_memory().percent:.0f}% '
+        msg += f'temp: {self.get_jetson_cpu_temperature():.1f}°C '
+        msg += f'battery: {self.field_friend.bms.state.short_string}'
         self.log.info(msg)

--- a/field_friend/vision/simulated_cam_provider.py
+++ b/field_friend/vision/simulated_cam_provider.py
@@ -51,3 +51,6 @@ class SimulatedCamProvider(rosys.vision.CameraProvider[SimulatedCam], rosys.pers
             new_id = f'cam{len(self._cameras)}'
             print(f'adding simulated camera: {new_id}')
             self.add_camera(SimulatedCam(id=new_id, width=640, height=480))
+
+    async def update_device_list(self) -> None:
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ geopy
 shapely
 fiona
 geopandas
-rosys == 0.10.10
+rosys == 0.11
 uvicorn == 0.28.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,11 @@ import pytest
 import rosys
 from rosys.testing import forward, helpers
 
+from field_friend import localization
 from field_friend.automations import Field
 from field_friend.localization import GeoPoint, GnssSimulation
 from field_friend.system import System
+
 
 ROBOT_GEO_START_POSITION = GeoPoint(lat=51.983173401171236, long=7.434163443756093)
 
@@ -21,7 +23,7 @@ async def system(integration, request) -> AsyncGenerator[System, None]:
     s = System()
     assert isinstance(s.detector, rosys.vision.DetectorSimulation)
     s.detector.detection_delay = 0.1
-    s.gnss.reference = ROBOT_GEO_START_POSITION
+    localization.reference = ROBOT_GEO_START_POSITION
     helpers.odometer = s.odometer
     helpers.driver = s.driver
     helpers.automator = s.automator

--- a/tests/test_field_creator.py
+++ b/tests/test_field_creator.py
@@ -1,22 +1,19 @@
 import pytest
-import rosys
 from rosys.geometry import Point
 
-from field_friend import System
-from field_friend.automations import Row
+from field_friend import System, localization
 from field_friend.interface.components.field_creator import FieldCreator
 from field_friend.localization import GeoPoint
 
 
 def test_geometry_computation(system: System):
     field_creator = FieldCreator(system)
+    localization.reference = GeoPoint(lat=51.98317071260942, long=7.43411239981148)
     field_creator.first_row_start = GeoPoint(lat=51.98317071260942, long=7.43411239981148)
     field_creator.first_row_end = field_creator.first_row_start.shifted(Point(x=0, y=10))
     field_creator.last_row_end = field_creator.first_row_start.shifted(Point(x=10, y=10))
-    assert field_creator.field.reference is None
     assert field_creator.build_geometry()
     assert len(field_creator.field.rows) == 20
-    assert field_creator.field.reference == field_creator.first_row_start
     outline = field_creator.field.outline
     assert len(outline) == 4
     assert outline[0].x == pytest.approx(-field_creator.padding)

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -9,14 +9,12 @@ from field_friend.localization import GnssSimulation
 
 
 def test_loading_from_old_persistence():
-    field_provider = FieldProvider(GnssSimulation(rosys.driving.Odometer(rosys.hardware.WheelsSimulation())))
+    wheels = rosys.hardware.WheelsSimulation()
+    field_provider = FieldProvider(GnssSimulation(rosys.driving.Odometer(wheels), wheels))
     field_provider.restore(json.loads(Path('tests/old_field_provider_persistence.json').read_text()))
     assert len(field_provider.fields) == 3
     field = field_provider.fields[1]
     assert len(field.points) == 4
-    assert field.reference is not None
-    assert field.reference.lat == pytest.approx(51.98, rel=0.01)
-    assert field.reference.long == pytest.approx(7.43, rel=0.01)
     assert len(field.rows) == 2
     row = field.rows[1]
     assert len(row.points) == 2

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -1,12 +1,13 @@
 
-from copy import deepcopy
 
+from copy import deepcopy
 
 import pytest
 import rosys
 from conftest import ROBOT_GEO_START_POSITION
 from rosys.testing import assert_point, forward
 
+from field_friend import localization
 from field_friend.localization import GeoPoint, GnssSimulation
 from field_friend.system import System
 
@@ -19,11 +20,12 @@ def test_distance_calculation():
 
 def test_shifted_calculation():
     point = GeoPoint(lat=51.983159, long=7.434212)
+    localization.reference = deepcopy(point)
     shifted = point.shifted(rosys.geometry.Point(x=6, y=6))
     # coordinates should be x pointing north, y pointing west (verified with https://www.meridianoutpost.com/resources/etools/calculators/calculator-latitude-longitude-distance.php?)
-    assert shifted.lat == 51.98321292429539
-    assert shifted.long == 7.43412466846196
-    assert_point(shifted.cartesian(point), rosys.geometry.Point(x=6, y=6))
+    assert shifted.lat == pytest.approx(51.983212924295)
+    assert shifted.long == pytest.approx(7.434124668461)
+    assert_point(shifted.cartesian(), rosys.geometry.Point(x=6, y=6))
 
 
 async def test_driving(gnss_driving: System):
@@ -75,20 +77,3 @@ async def test_record_is_none(gnss_driving: System, gnss: GnssSimulation):
     await forward(5)
     # robot should have stopped driving
     assert_point(gnss_driving.odometer.prediction.point, rosys.geometry.Point(x=2, y=0))
-
-
-async def test_changing_reference(gnss_driving: System):
-    assert gnss_driving.gnss.current is not None
-    assert gnss_driving.gnss.reference is not None
-    assert gnss_driving.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
-    assert gnss_driving.gnss.reference.distance(ROBOT_GEO_START_POSITION) < 0.01
-    await forward(x=2.0, tolerance=0.001)
-    gnss_driving.automator.pause('changing reference point')
-    await forward(2)
-    assert gnss_driving.gnss.current.location.distance(ROBOT_GEO_START_POSITION) == pytest.approx(2.0, 0.1)
-    location = deepcopy(gnss_driving.gnss.current.location)
-    gnss_driving.gnss.reference = gnss_driving.gnss.reference.shifted(rosys.geometry.Point(x=-3.0, y=0.0))
-    await forward(2)
-    assert gnss_driving.odometer.prediction.point.x == pytest.approx(5.0)
-    assert gnss_driving.odometer.prediction.point.y == pytest.approx(0.0)
-    assert location == gnss_driving.gnss.current.location

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,3 +1,5 @@
+import random
+
 import numpy as np
 import pytest
 import rosys
@@ -6,8 +8,9 @@ from rosys.testing import forward
 
 from field_friend import System
 from field_friend.automations import Field
-from field_friend.automations.implements import Recorder
+from field_friend.automations.implements import Implement, Recorder
 from field_friend.automations.navigation import StraightLineNavigation
+from field_friend.localization import GnssSimulation
 
 
 async def test_straight_line(system: System):
@@ -15,28 +18,105 @@ async def test_straight_line(system: System):
     assert isinstance(system.current_navigation, StraightLineNavigation)
     assert isinstance(system.current_navigation.implement, Recorder)
     system.automator.start()
-    await forward(2)
-    assert system.automator.is_running
-    await forward(55)
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.automator.is_stopped)
     assert not system.automator.is_running, 'automation should stop after default length'
     assert system.odometer.prediction.point.x == pytest.approx(system.straight_line_navigation.length, abs=0.1)
 
 
+async def test_straight_line_with_failing_gnss(system: System, gnss: GnssSimulation, detector: rosys.vision.DetectorSimulation):
+    async def empty():
+        return None
+    create_new_record = gnss._create_new_record
+    system.automator.start()
+    await forward(5)
+    gnss._create_new_record = empty  # type: ignore
+    await forward(0.5)
+    gnss._create_new_record = create_new_record
+    await forward(5)
+    assert system.automator.is_running
+    assert len(detector.simulated_objects) == 0
+    assert system.odometer.prediction.yaw_deg == pytest.approx(0, abs=1)
+
+
+async def test_driving_to_exact_positions(system: System):
+    class Stopper(Implement):
+        def __init__(self, system: System) -> None:
+            super().__init__('Stopper')
+            self.system = system
+            self.current_stretch = 0.0
+            self.workflow_started = False
+
+        async def get_stretch(self, max_distance: float) -> float:
+            self.current_stretch = random.uniform(0.02, max_distance)
+            return self.current_stretch
+
+        async def start_workflow(self) -> None:
+            self.workflow_started = True
+            deadline = rosys.time() + 1
+            while self.workflow_started and rosys.time() < deadline:
+                await rosys.sleep(0.1)
+            self.workflow_started = False
+
+    system.current_implement = stopper = Stopper(system)
+    assert isinstance(system.current_navigation, StraightLineNavigation)
+    system.current_navigation.linear_speed_limit = 0.05  # drive really slow so we can archive the accuracy tested below
+    system.automator.start()
+
+    await forward(until=lambda: system.automator.is_running, dt=0.01)
+    for _ in range(20):
+        old_position = system.odometer.prediction.point
+        await forward(until=lambda: stopper.workflow_started and system.automator.is_running, dt=0.01)
+        distance = old_position.distance(system.odometer.prediction.point)
+        assert distance == pytest.approx(stopper.current_stretch, abs=0.001)
+        stopper.workflow_started = False
+        await forward(0.1)  # give robot time to update position
+
+
+async def test_driving_straight_line_with_slippage(system: System):
+    assert isinstance(system.field_friend.wheels, rosys.hardware.WheelsSimulation)
+    assert isinstance(system.current_navigation, StraightLineNavigation)
+    system.current_navigation.length = 1.0
+    system.field_friend.wheels.slip_factor_right = 0.05
+    system.automator.start()
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.automator.is_stopped)
+    assert system.odometer.prediction.point.x == pytest.approx(1.0, abs=0.1)
+    assert system.odometer.prediction.point.y == pytest.approx(0.0, abs=0.1)
+
+
 async def test_follow_crops(system: System, detector: rosys.vision.DetectorSimulation):
-    for i in range(10):
+    for i in range(20):
         x = i/10.0
-        p = rosys.geometry.Point3d(x=x, y=np.sin(x/2), z=0)
+        p = rosys.geometry.Point3d(x=x, y=(x/2) ** 3, z=0)
+        p = system.odometer.prediction.transform3d(p)
         detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='maize', position=p))
     system.current_navigation = system.follow_crops_navigation
     assert isinstance(system.current_navigation.implement, Recorder)
     system.automator.start()
-    await forward(2)
-    assert system.automator.is_running
-    await forward(50)
-    assert not system.automator.is_running, 'automation should stop if no crops are detected anymore'
-    assert system.odometer.prediction.point.x == pytest.approx(1.4, abs=0.1)
-    assert system.odometer.prediction.point.y == pytest.approx(0.6, abs=0.1)
-    assert system.odometer.prediction.yaw_deg == pytest.approx(25.0, abs=5.0)
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.automator.is_stopped)
+    assert system.odometer.prediction.point.x == pytest.approx(2.2, abs=0.1)
+    assert system.odometer.prediction.point.y == pytest.approx(0.45, abs=0.1)
+    assert system.odometer.prediction.yaw_deg == pytest.approx(40.0, abs=5.0)
+
+
+async def test_follow_crops_with_slippage(system: System, detector: rosys.vision.DetectorSimulation):
+    for i in range(20):
+        x = i/10.0
+        p = rosys.geometry.Point3d(x=x, y=(x/3) ** 3, z=0)
+        p = system.odometer.prediction.transform3d(p)
+        detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='maize', position=p))
+        print(p)
+    assert isinstance(system.field_friend.wheels, rosys.hardware.WheelsSimulation)
+    system.current_navigation = system.follow_crops_navigation
+    system.field_friend.wheels.slip_factor_right = 0.05
+    system.automator.start()
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.automator.is_stopped)
+    assert system.odometer.prediction.point.x == pytest.approx(2.3, abs=0.1)
+    assert system.odometer.prediction.point.y == pytest.approx(0, abs=0.1)
+    assert system.odometer.prediction.yaw_deg == pytest.approx(25.0, abs=2.0)
 
 
 async def test_approaching_first_row(system: System, field: Field):
@@ -45,22 +125,22 @@ async def test_approaching_first_row(system: System, field: Field):
     assert system.gnss.current
     assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
     system.automator.start()
-    await forward(x=1.5, y=-6.05)
+    await forward(until=lambda: system.field_navigation.state == system.field_navigation.State.APPROACHING_ROW_START)
+    await forward(1)
     assert system.field_navigation.current_row == field.rows[0]
-    assert system.field_navigation.state == system.field_navigation.State.APPROACHING_ROW_START
     assert system.field_navigation.automation_watcher.field_watch_active
     await forward(5)
     assert system.automator.is_running
     assert system.field_navigation.current_row == field.rows[0]
-    assert system.field_navigation.state == system.field_navigation.State.FOLLOWING_ROW
+    await forward(until=lambda: system.field_navigation.state == system.field_navigation.State.FOLLOWING_ROW)
     assert system.field_navigation.automation_watcher.field_watch_active
 
 
-async def test_not_approaching_first_row_when_outside_field(system: System, field: Field):
+async def test_approaching_first_row_when_outside_of_field(system: System, field: Field):
     async def drive_away():
-        await system.driver.drive_to(rosys.geometry.Point(x=-5, y=0))
+        await system.driver.drive_to(rosys.geometry.Point(x=-5, y=0), backward=True)
     system.automator.start(drive_away())
-    await forward(22)
+    await forward(50)
     assert not system.automator.is_running
 
     system.field_navigation.field = field
@@ -72,14 +152,16 @@ async def test_not_approaching_first_row_when_outside_field(system: System, fiel
     assert not system.automator.is_running, 'should have been stopped because robot is outside of field boundaries'
 
 
+@pytest.mark.skip('does not work anymore due to gps using wheels.pose instead of odometry.pose')
 async def test_resuming_field_navigation_after_automation_stop(system: System, field: Field):
     system.field_navigation.field = field
     system.current_navigation = system.field_navigation
     system.automator.start()
     assert field.reference
     await forward(1)  # update gnss reference to use the fields reference
-    point = rosys.geometry.Point(x=1.50, y=-6.1)
+    point = rosys.geometry.Point(x=1.54, y=-6.1)
     await forward(x=point.x, y=point.y, tolerance=0.01)  # drive until we are on first row
+    await forward(2)
     assert system.field_navigation.state == system.field_navigation.State.FOLLOWING_ROW
     system.automator.stop(because='test')
     await forward(2)

--- a/tests/test_weeding.py
+++ b/tests/test_weeding.py
@@ -77,6 +77,56 @@ async def test_weeding_screw_focus_on_weed_close_to_crop(system: System, detecto
     assert detector.simulated_objects[1].position.x == 0.1
 
 
+@pytest.mark.parametrize('cultivated_crop', ['maize', None])
+async def test_weeding_screw_advances_when_there_are_no_plants(system: System, detector: rosys.vision.DetectorSimulation, cultivated_crop: str | None):
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=0.2, y=-0.05, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=1.290, y=-0.04, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='maize',
+                                                                   position=rosys.geometry.Point3d(x=1.285, y=0, z=0)))
+    assert detector.simulated_objects[1].category_name == 'weed'
+    system.current_implement = system.implements['Weed Screw']
+    system.current_navigation = system.straight_line_navigation
+    system.current_navigation.length = 1.5
+    assert isinstance(system.current_implement, WeedingScrew)
+    system.current_implement.cultivated_crop = cultivated_crop
+    # TODO: test fails if not forwarded by 1 second
+    await forward(1)
+    system.automator.start()
+    await forward(60)
+    assert system.odometer.prediction.point.x == pytest.approx(system.straight_line_navigation.length, abs=0.1)
+    if cultivated_crop is None:
+        assert len(detector.simulated_objects) == 1
+    elif cultivated_crop == 'maize':
+        assert len(detector.simulated_objects) == 2
+    assert detector.simulated_objects[-1].category_name == 'maize'
+
+
+async def test_weeding_screw_advances_when_there_are_no_weeds_close_enough_to_the_crop(system: System, detector: rosys.vision.DetectorSimulation):
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=0.2, y=-0.08, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='maize',
+                                                                   position=rosys.geometry.Point3d(x=0.2, y=0, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=0.3, y=-0.08, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='maize',
+                                                                   position=rosys.geometry.Point3d(x=0.3, y=0, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=0.34, y=0, z=0)))
+    assert len(detector.simulated_objects) == 5
+    system.current_implement = system.implements['Weed Screw']
+    system.current_navigation = system.straight_line_navigation
+    system.current_navigation.length = 1.5
+    assert isinstance(system.current_implement, WeedingScrew)
+    system.current_implement.cultivated_crop = 'maize'
+    system.current_implement.max_crop_distance = 0.050
+    system.automator.start()
+    await forward(50)
+    assert system.odometer.prediction.point.x == pytest.approx(system.straight_line_navigation.length, abs=0.1)
+    assert len(detector.simulated_objects) == 4, 'last weed should be removed'
+
+
 @pytest.mark.parametrize('system', ['rb28'], indirect=True)
 async def test_tornado_removes_weeds_around_crop(system: System, detector: rosys.vision.DetectorSimulation):
     detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',


### PR DESCRIPTION
Due to the fact that U4 with Tornado has the only closed-loop stepper motor which is not adressed with CAN as later stepper motors. A fix for the internal alarm is necessary. 

- [x] Creating quick fix for U4
- [x] Fixing the invert of the alarm with use of config file to set the hardware when setting up the robot.
- [x] Test on U4
- [x] Test on other robot (should not have an influence)

Test steps:
- [x] Deploy code without updating the config. It should raise a KeyError
- [x] Update the config
- [x] Drive and reference the robot