### PR TITLE
Fix punch dialog for the refactorings which have been done on #102

### DIFF
--- a/field_friend/automations/implements/implement.py
+++ b/field_friend/automations/implements/implement.py
@@ -24,7 +24,7 @@ class Implement(abc.ABC):
         """Deactivate the implement (for example to stop weeding at the row's end)"""
         self.is_active = False
 
-    def get_stretch(self) -> float:
+    async def get_stretch(self, max_distance: float) -> float:
         """Return the stretch which the implement thinks is safe to drive forward."""
         return 0.02
 

--- a/field_friend/automations/implements/punch_dialog.py
+++ b/field_friend/automations/implements/punch_dialog.py
@@ -70,16 +70,8 @@ class PunchDialog(ui.dialog):
     def setup_camera(self) -> None:
         cameras = list(self.camera_provider.cameras.values())
         active_camera = next((camera for camera in cameras if camera.is_connected), None)
-        if not active_camera:
-            if self.camera:
-                self.camera = None
-                self.camera_card.clear()
-                with self.camera_card:
-                    ui.label('no camera available').classes('text-center')
-                    ui.image('assets/field_friend.webp').classes('w-full')
-            return
-        if self.camera is None or self.camera != active_camera:
-            self.camera = active_camera
+        assert active_camera is not None
+        self.camera = active_camera
 
     def update_content(self, image_view: ui.interactive_image, image: Image, draw_target: bool = False) -> None:
         self._duration_left -= self.ui_update_rate
@@ -106,6 +98,7 @@ class PunchDialog(ui.dialog):
 
     def update_live_view(self) -> None:
         if self.camera is None:
+            self.live_image_view.set_source('assets/field_friend.webp')
             return
         self.update_content(self.live_image_view, self.camera.latest_detected_image)
 

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -33,7 +33,7 @@ class Tornado(WeedingImplement):
             open_drill = False
             if self.drill_with_open_tornado:
                 open_drill = True
-            await self.system.puncher.punch(y=self.next_punch_y_position,   angle=self.tornado_angle, with_open_tornado=open_drill)
+            await self.system.puncher.punch(y=self.next_punch_y_position, angle=self.tornado_angle, with_open_tornado=open_drill)
             # TODO remove weeds from plant_provider and increment kpis (like in Weeding Screw)
             if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
                 # remove the simulated weeds

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -33,10 +33,7 @@ class Tornado(WeedingImplement):
             open_drill = False
             if self.drill_with_open_tornado:
                 open_drill = True
-            await self.system.puncher.punch(y=self.next_punch_y_position,
-                                            angle=self.tornado_angle,
-                                            with_open_tornado=open_drill,
-                                            with_punch_check=self.with_punch_check)
+            await self.system.puncher.punch(y=self.next_punch_y_position,   angle=self.tornado_angle, with_open_tornado=open_drill)
             # TODO remove weeds from plant_provider and increment kpis (like in Weeding Screw)
             if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
                 # remove the simulated weeds
@@ -55,7 +52,8 @@ class Tornado(WeedingImplement):
         except Exception as e:
             raise ImplementException('Error while tornado Workflow') from e
 
-    def get_stretch(self) -> float:
+    async def get_stretch(self, max_distance: float) -> float:
+        await super().get_stretch(max_distance)
         super()._has_plants_to_handle()
         if len(self.crops_to_handle) == 0:
             return self.WORKING_DISTANCE
@@ -85,8 +83,10 @@ class Tornado(WeedingImplement):
             stretch = 0
         self.log.info(f'Targeting crop {closest_crop_id} which is {stretch} away at world: '
                       f'{closest_crop_world_position}, local: {closest_crop_position}')
-        self.next_punch_y_position = closest_crop_position.y
-        return stretch
+        if stretch < max_distance and await self.ask_for_punch(closest_crop_id):
+            self.next_punch_y_position = closest_crop_position.y
+            return stretch
+        return self.WORKING_DISTANCE
 
     def _crops_in_drill_range(self, crop_id: str, crop_position: rosys.geometry.Point, angle: float) -> bool:
         inner_diameter, outer_diameter = self.system.field_friend.tornado_diameters(angle)

--- a/field_friend/automations/implements/weeding_implement.py
+++ b/field_friend/automations/implements/weeding_implement.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections import deque
 from typing import TYPE_CHECKING, Any, Optional
@@ -8,6 +9,7 @@ from rosys.geometry import Point, Pose
 
 from ...hardware import ChainAxis
 from .implement import Implement
+from .punch_dialog import PunchDialog
 
 if TYPE_CHECKING:
     from system import System
@@ -48,6 +50,7 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
         self.last_punches: deque[rosys.geometry.Point] = deque(maxlen=5)
         self.next_punch_y_position: float = 0
 
+        self.punch_dialog: PunchDialog | None = None
         rosys.on_repeat(self._update_time_and_distance, 0.1)
 
     async def prepare(self) -> bool:
@@ -216,3 +219,19 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
         ui.checkbox('With punch check', value=True) \
             .bind_value(self, 'with_punch_check') \
             .tooltip('Set the weeding automation to check for punch')
+        self.punch_dialog = PunchDialog(self.system)
+
+    async def ask_for_punch(self, plant_id: str | None = None) -> bool:
+        if not self.with_punch_check or plant_id is None or self.punch_dialog is None:
+            return True
+        self.punch_dialog.target_plant = self.system.plant_provider.get_plant_by_id(plant_id)
+        result: str | None = None
+        try:
+            result = await asyncio.wait_for(self.punch_dialog, timeout=self.punch_dialog.timeout)
+            if result == 'Yes':
+                self.log.info('punching was allowed')
+                return True
+        except asyncio.TimeoutError:
+            self.punch_dialog.close()
+        self.log.warning('punch was not allowed')
+        return False

--- a/field_friend/automations/implements/weeding_screw.py
+++ b/field_friend/automations/implements/weeding_screw.py
@@ -25,7 +25,7 @@ class WeedingScrew(WeedingImplement):
             punch_position = self.system.odometer.prediction.transform(
                 rosys.geometry.Point(x=self.system.field_friend.WORK_X, y=self.next_punch_y_position))
             self.last_punches.append(punch_position)
-            await self.system.puncher.punch(y=self.next_punch_y_position, depth=self.weed_screw_depth,)
+            await self.system.puncher.punch(y=self.next_punch_y_position, depth=self.weed_screw_depth)
             punched_weeds = [weed.id for weed in self.system.plant_provider.get_relevant_weeds(self.system.odometer.prediction.point)
                              if weed.position.distance(punch_position) <= self.system.field_friend.DRILL_RADIUS]
             for weed_id in punched_weeds:

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -16,6 +16,7 @@ class WorkflowException(Exception):
 
 
 class Navigation(rosys.persistence.PersistentModule):
+    MAX_STRETCH_DISTANCE = 0.05
 
     def __init__(self, system: 'System', implement: Implement) -> None:
         super().__init__()
@@ -42,9 +43,8 @@ class Navigation(rosys.persistence.PersistentModule):
             if isinstance(self.driver.wheels, rosys.hardware.WheelsSimulation) and not rosys.is_test:
                 self.create_simulation()
             while not self._should_finish():
-                max = 0.05
-                distance = await self.implement.get_stretch(max)
-                if distance > max:  # we do not want to drive to long without observing
+                distance = await self.implement.get_stretch(self.MAX_STRETCH_DISTANCE)
+                if distance > self.MAX_STRETCH_DISTANCE:  # we do not want to drive to long without observing
                     await self._drive(0.02)
                     continue
                 await self._drive(distance)

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -17,6 +17,7 @@ class WorkflowException(Exception):
 
 class Navigation(rosys.persistence.PersistentModule):
     MAX_STRETCH_DISTANCE = 0.05
+    DEFAULT_DRIVE_DISTANCE = 0.02
 
     def __init__(self, system: 'System', implement: Implement) -> None:
         super().__init__()
@@ -45,7 +46,7 @@ class Navigation(rosys.persistence.PersistentModule):
             while not self._should_finish():
                 distance = await self.implement.get_stretch(self.MAX_STRETCH_DISTANCE)
                 if distance > self.MAX_STRETCH_DISTANCE:  # we do not want to drive to long without observing
-                    await self._drive(0.02)
+                    await self._drive(self.DEFAULT_DRIVE_DISTANCE)
                     continue
                 await self._drive(distance)
                 await self.implement.start_workflow()

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -42,8 +42,9 @@ class Navigation(rosys.persistence.PersistentModule):
             if isinstance(self.driver.wheels, rosys.hardware.WheelsSimulation) and not rosys.is_test:
                 self.create_simulation()
             while not self._should_finish():
-                distance = self.implement.get_stretch()
-                if distance > 0.05:  # we do not want to drive to long without observing
+                max = 0.05
+                distance = await self.implement.get_stretch(max)
+                if distance > max:  # we do not want to drive to long without observing
                     await self._drive(0.02)
                     continue
                 await self._drive(distance)

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -17,8 +17,6 @@ class PuncherException(Exception):
 
 class Puncher:
     def __init__(self, field_friend: FieldFriend, driver: Driver, kpi_provider: KpiProvider) -> None:
-        self.POSSIBLE_PUNCH = rosys.event.Event()
-        '''Event that is emitted when a punch is possible.'''
         self.punch_allowed: str = 'waiting'
         self.field_friend = field_friend
         self.driver = driver
@@ -64,9 +62,7 @@ class Puncher:
                     depth: float = 0.01,
                     angle: float = 180,
                     turns: float = 2.0,
-                    plant_id: Optional[str] = None,
                     with_open_tornado: bool = False,
-                    with_punch_check: bool = False,
                     ) -> None:
         self.log.info(f'Punching at {y} with depth {depth}...')
         rest_position = 'reference'
@@ -92,16 +88,6 @@ class Puncher:
                 if not self.field_friend.y_axis.min_position <= y <= self.field_friend.y_axis.max_position:
                     rosys.notify('y position out of range', type='negative')
                     raise PuncherException('y position out of range')
-                
-            if with_punch_check and plant_id is not None:
-                self.punch_allowed = 'waiting'
-                self.POSSIBLE_PUNCH.emit(plant_id)
-                while self.punch_allowed == 'waiting':
-                    await rosys.sleep(0.1)
-                if self.punch_allowed == 'not_allowed':
-                    self.log.warning('punch was not allowed')
-                    return
-                self.log.info('punching was allowed')
 
             if isinstance(self.field_friend.z_axis, Tornado):
                 await self.field_friend.y_axis.move_to(y)
@@ -119,7 +105,7 @@ class Puncher:
             self.log.info(f'punched at {y:.2f} with depth {depth}, now back to rest position "{rest_position}"')
             self.kpi_provider.increment_weeding_kpi('punches')
         except Exception as e:
-            raise PuncherException(f'punching failed because: {e}') from e
+            raise PuncherException('punching failed') from e
         finally:
             await self.field_friend.y_axis.stop()
             await self.field_friend.z_axis.stop()

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -1,13 +1,9 @@
-
-import asyncio
 import logging
 from typing import TYPE_CHECKING
 
 from nicegui import app, events, ui
 
-from .field_creator import FieldCreator
 from .key_controls import KeyControls
-from .punch_dialog import PunchDialog
 
 if TYPE_CHECKING:
     from field_friend.system import System
@@ -55,22 +51,6 @@ class operation:
                 .tooltip('Select the implement to work with') \
                 .bind_value_from(self.system, 'current_implement', lambda i: i.name)
             self.implement_selection.value = self.system.current_implement.name
-
-        self.system.puncher.POSSIBLE_PUNCH.register_ui(self.can_punch)
-        self.punch_dialog = PunchDialog(self.system)
-
-    async def can_punch(self, plant_id: str) -> None:
-        self.punch_dialog.target_plant = self.system.plant_provider.get_plant_by_id(plant_id)
-        result: str | None = None
-        try:
-            result = await asyncio.wait_for(self.punch_dialog, timeout=self.punch_dialog.timeout)
-        except asyncio.TimeoutError:
-            self.punch_dialog.close()
-            result = None
-        if result == 'Yes':
-            self.system.puncher.punch_allowed = 'allowed'
-        elif result is None or result == 'No' or result == 'Cancel':
-            self.system.puncher.punch_allowed = 'not_allowed'
 
     def handle_implement_changed(self, e: events.ValueChangeEventArguments) -> None:
         if self.system.current_implement.name != e.value:


### PR DESCRIPTION
This pull request moves the punch dialog into weeding implements to simplify architecture. The `get_stretch` is the only place where the plant_id is ready available so it makes sense to ask the user there.
