### PR TITLE
Add milestone_check action 

### DIFF
--- a/.github/workflows/milestone_check.yml
+++ b/.github/workflows/milestone_check.yml
@@ -1,0 +1,17 @@
+name: Milestone Assigned
+
+on:
+  pull_request:
+    types: [milestoned, demilestoned, opened]
+
+jobs:
+  check-milestone:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for milestone
+        run: |
+          if [ -z "${{ github.event.pull_request.milestone }}" ]; then
+            echo "No milestone assigned to the pull request."
+            exit 1
+          fi


### PR DESCRIPTION
We added an action to Rosys that checks whether a milestone is set for a PR or not ([Link](https://github.com/zauberzeug/rosys/pull/143)). This PR adds the same