### PR TITLE
Display weed locations as white dots in camera augmentation on real robot

### DIFF
--- a/field_friend/interface/components/camera_card.py
+++ b/field_friend/interface/components/camera_card.py
@@ -243,9 +243,9 @@ class camera_card:
                 # TODO remove this when RoSys supports multiple extrinsics (see https://github.com/zauberzeug/rosys/discussions/130)
                 relative = self.system.odometer.prediction.relative_point(position)
                 screen = self.odometer.prediction.transform(relative.projection())
-        if screen is not None:
-            svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" fill="white" />'
-            svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+16}" fill="black" font-size="9" text-anchor="middle">{plant.id[:4]}</text>'
+            if screen is not None:
+                svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" fill="white" />'
+                svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+16}" fill="black" font-size="9" text-anchor="middle">{plant.id[:4]}</text>'
         return svg
 
     # async def save_last_image(self) -> None:

--- a/field_friend/interface/components/camera_card.py
+++ b/field_friend/interface/components/camera_card.py
@@ -242,7 +242,7 @@ class camera_card:
             else:
                 # TODO remove this when RoSys supports multiple extrinsics (see https://github.com/zauberzeug/rosys/discussions/130)
                 relative = self.system.odometer.prediction.relative_point(position)
-                screen = self.odometer.prediction.transform(relative.projection())
+                screen = self.odometer.prediction.transform(relative)
             if screen is not None:
                 svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" fill="white" />'
                 svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+16}" fill="black" font-size="9" text-anchor="middle">{plant.id[:4]}</text>'


### PR DESCRIPTION
This introduces another place for the work around we use already in other parts of the code until https://github.com/zauberzeug/rosys/discussions/13 is implemented. It allows the weeds of the plant provider to be rendered as white dots in the CameraCard.