### PR TITLE
Remove individual field references in favour of a simplified "global" reference for all coordinates

### DIFF
--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 
 import rosys
 from shapely.geometry import Polygon
@@ -23,14 +22,13 @@ class Row(GeoPointCollection):
             points=list(reversed(self.points)),
         )
 
-    def line_segment(self, reference: GeoPoint) -> rosys.geometry.LineSegment:
-        return rosys.geometry.LineSegment(point1=self.points[0].cartesian(reference),
-                                          point2=self.points[-1].cartesian(reference))
+    def line_segment(self) -> rosys.geometry.LineSegment:
+        return rosys.geometry.LineSegment(point1=self.points[0].cartesian(),
+                                          point2=self.points[-1].cartesian())
 
 
 @dataclass(slots=True, kw_only=True)
 class Field(GeoPointCollection):
-    reference: Optional[GeoPoint] = None
     visualized: bool = False
     obstacles: list[FieldObstacle] = field(default_factory=list)
     rows: list[Row] = field(default_factory=list)
@@ -38,8 +36,7 @@ class Field(GeoPointCollection):
 
     @property
     def outline(self) -> list[rosys.geometry.Point]:
-        assert self.reference is not None
-        return self.cartesian(self.reference)
+        return self.cartesian()
 
     @property
     def outline_as_tuples(self) -> list[tuple[float, float]]:

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -75,7 +75,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
         if self.gnss.current is None:
             rosys.notify('No GNSS position available.')
             return
-        self.clear_fields()
         localization.reference = self.gnss.current.location
         os.utime('main.py')
 

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -43,10 +43,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
             outline = fields_data[i].get('outline_wgs84', [])
             for coords in outline:
                 f.points.append(GeoPoint(lat=coords[0], long=coords[1]))
-            rlat = fields_data[i].get('reference_lat', None)
-            rlong = fields_data[i].get('reference_lon', None)
-            if rlat is not None and rlong is not None:
-                f.reference = GeoPoint(lat=rlat, long=rlong)
             rows = fields_data[i].get('rows', [])
             for j, row in enumerate(rows):
                 for point in row.get('points_wgs84', []):
@@ -74,10 +70,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.fields.clear()
         self.FIELDS_CHANGED.emit()
         self.invalidate()
-
-    def set_reference(self, field: Field, point: GeoPoint) -> None:
-        if field.reference is None:
-            field.reference = point
 
     def create_obstacle(self, field: Field, points: list[GeoPoint] = []) -> FieldObstacle:
         obstacle = FieldObstacle(id=f'{str(uuid.uuid4())}', name=f'obstacle_{len(field.obstacles)+1}', points=points)
@@ -141,25 +133,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.fields[field_index].rows = sorted(field.rows, key=lambda row: get_distance(row, direction=direction))
         self.FIELDS_CHANGED.emit()
 
-    def ensure_field_reference(self, field: Field) -> None:
-        if self.gnss.device is None:
-            self.log.warning('not creating Reference because no GNSS device found')
-            rosys.notify('No GNSS device found', 'negative')
-            return
-        if self.gnss.current is None or self.gnss.current.gps_qual != 4:
-            self.log.warning('not creating Reference because no RTK fix available')
-            rosys.notify('No RTK fix available', 'negative')
-            return
-        if field.reference is None:
-            ref = self.gnss.reference
-            if ref is None:
-                self.log.warning('not creating Point because no reference position available')
-                rosys.notify('No reference position available')
-                return
-            field.reference = ref
-        if self.gnss.reference != field.reference:
-            self.gnss.reference = field.reference
-
     async def add_field_point(self, field: Field, point: Optional[GeoPoint] = None, new_point: Optional[GeoPoint] = None) -> None:
         assert self.gnss.current is not None
         positioning = self.gnss.current.location
@@ -172,13 +145,8 @@ class FieldProvider(rosys.persistence.PersistentModule):
         new_point = positioning
         if point is not None:
             index = field.points.index(point)
-            if index == 0:
-                self.set_reference(field, new_point)
             field.points[index] = new_point
         else:
-            if len(field.points) < 1:
-                self.set_reference(field, new_point)
-                self.gnss.reference = new_point
             field.points.append(new_point)
         self.invalidate()
 

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -55,8 +55,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
     def create_field(self, points: list[GeoPoint] = []) -> Field:
         new_id = str(uuid.uuid4())
         field = Field(id=f'{new_id}', name=f'field_{len(self.fields)+1}', points=points)
-        if points:
-            self.set_reference(field, points[0])
         self.fields.append(field)
         self.invalidate()
         return field

--- a/field_friend/automations/navigation/coverage_navigation.py
+++ b/field_friend/automations/navigation/coverage_navigation.py
@@ -84,21 +84,16 @@ class CoverageNavigation(Navigation):
             self.log.error('Field is not available')
             rosys.notify('No field selected', 'negative')
             return False
-        if not self.field.reference:
-            self.log.error('Field reference is not available')
-            return False
-        self.system.gnss.reference = self.field.reference
         if self.padding < self.robot_width+self.lane_distance:
             self.padding = self.robot_width+self.lane_distance
 
         self.path_planner.obstacles.clear()
         self.path_planner.areas.clear()
         assert self.field is not None
-        assert self.field.reference is not None
         for obstacle in self.field.obstacles:
             self.path_planner.obstacles[obstacle.id] = \
                 rosys.pathplanning.Obstacle(id=obstacle.id,
-                                            outline=obstacle.cartesian(self.field.reference))
+                                            outline=obstacle.cartesian())
         area = rosys.pathplanning.Area(id=f'{self.field.id}', outline=self.field.outline)
         self.path_planner.areas = {area.id: area}
         self.paths = self._generate_mowing_path()

--- a/field_friend/automations/navigation/row_on_field_navigation.py
+++ b/field_friend/automations/navigation/row_on_field_navigation.py
@@ -67,7 +67,6 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
 
     async def _drive(self, distance: float) -> None:
         assert self.field is not None
-        assert self.field.reference is not None
         if self.state == self.State.APPROACHING_ROW_START:
             # TODO only drive to row if we are not on any rows and near the row start
             await self._drive_to_row(self.current_row)
@@ -77,7 +76,7 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         if self.state == self.State.FOLLOWING_ROW:
             if not self.implement.is_active:
                 await self.implement.activate()
-            if self.odometer.prediction.point.distance(self.current_row.points[-1].cartesian(self.field.reference)) >= 0.1:
+            if self.odometer.prediction.point.distance(self.current_row.points[-1].cartesian()) >= 0.1:
                 await super()._drive(distance)
             else:
                 await self.implement.deactivate()
@@ -85,12 +84,12 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
                 self.log.info('Returning to start...')
         if self.state == self.State.RETURNING_TO_START:
             self.driver.parameters.can_drive_backwards = True
-            end = self.current_row.points[0].cartesian(self.field.reference)
+            end = self.current_row.points[0].cartesian()
             await self.driver.drive_to(end, backward=True)  # TODO replace with following crops or replay recorded path
             inverse_yaw = (self.odometer.prediction.yaw + math.pi) % (2 * math.pi)
             next_row = self.field.rows[self.row_index + 1] if self.row_index + \
                 1 < len(self.field.rows) else self.current_row
-            between = end.interpolate(next_row.points[0].cartesian(self.field.reference), 0.5)
+            between = end.interpolate(next_row.points[0].cartesian(), 0.5)
             await self.driver.drive_to(between.polar(1.5, inverse_yaw), backward=True)
             self.driver.parameters.can_drive_backwards = False
             self.state = self.State.ROW_COMPLETED
@@ -107,9 +106,9 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
 
     async def _drive_to_row(self, row: Row):
         self.log.info(f'Driving to "{row.name}"...')
-        assert self.field and self.field.reference
-        target = row.points[0].cartesian(self.field.reference)
-        direction = target.direction(row.points[-1].cartesian(self.field.reference))
+        assert self.field
+        target = row.points[0].cartesian()
+        direction = target.direction(row.points[-1].cartesian())
         end_pose = Pose(x=target.x, y=target.y, yaw=direction)
         spline = Spline.from_poses(self.odometer.prediction, end_pose)
         await self.driver.drive_spline(spline)

--- a/field_friend/automations/navigation/row_on_field_navigation.py
+++ b/field_friend/automations/navigation/row_on_field_navigation.py
@@ -39,9 +39,6 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         if self.field is None:
             rosys.notify('No field selected', 'negative')
             return False
-        if not self.field.reference:
-            rosys.notify('No field reference available', 'negative')
-            return False
         if not self.field.rows:
             rosys.notify('No rows available', 'negative')
             return False
@@ -55,13 +52,11 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         if self.state == self.State.FIELD_COMPLETED:
             self.clear()
         if self.state == self.State.FOLLOWING_ROW:
-            if self.current_row.line_segment(self.field.reference).distance(self.odometer.prediction.point) > 0.1:
+            if self.current_row.line_segment().distance(self.odometer.prediction.point) > 0.1:
                 self.clear()
         else:
             self.plant_provider.clear()
 
-        # NOTE: it's useful to set the reference point to the reference of the field; that way the cartesian coordinates are simpler to comprehend
-        self.gnss.reference = self.field.reference
         await rosys.sleep(0.1)  # wait for GNSS to update
         self.automation_watcher.start_field_watch(self.field.outline)
         return True
@@ -162,11 +157,10 @@ class RowsOnFieldNavigation(FollowCropsNavigation):
         self.detector.simulated_objects.clear()
         if self.field is None:
             return
-        assert self.field.reference is not None
         for row in self.field.rows:
             if len(row.points) < 2:
                 continue
-            cartesian = row.cartesian(self.field.reference)
+            cartesian = row.cartesian()
             start = cartesian[0]
             end = cartesian[-1]
             length = start.distance(end)

--- a/field_friend/automations/path_provider.py
+++ b/field_friend/automations/path_provider.py
@@ -10,7 +10,6 @@ from ..localization import GeoPoint
 class Path:
     name: str
     path_segments: list[rosys.driving.PathSegment] = field(default_factory=list)
-    reference: Optional[GeoPoint] = None
     visualized: bool = False
 
 

--- a/field_friend/automations/path_recorder.py
+++ b/field_friend/automations/path_recorder.py
@@ -36,11 +36,6 @@ class PathRecorder():
             self.log.warning(f'not recording path "{path.name}" not found')
             return
         self.log.info(f'recording path {path.name}')
-        if self.gnss.device != 'simulation':
-            if self.gnss.reference is None:
-                self.log.warning('not recording because no reference location set')
-                return
-            path.reference = self.gnss.reference
         rosys.notify(f'Recording...Please drive the path {path.name} now.')
         self.current_path_recording = path.name
         self.state = 'recording'
@@ -84,17 +79,6 @@ class PathRecorder():
         if path == []:
             self.log.warning(f'path {path.name} is empty')
             return
-        if self.gnss.device != 'simulation':
-            if path.reference is None:
-                self.log.warning('not driving because no reference location set')
-                return
-            # NOTE the target location is the path reference point; we do not approach a path if it is to far away
-            self.gnss.reference = path.reference
-            distance = self.gnss.distance(self.gnss.current)
-            if not distance or distance > 10:
-                self.log.warning('not driving because distance to reference location is too large')
-                rosys.notify('Distance to reference location is too large', 'negative')
-                return
         self.log.info(f'path: {path}')
         self.current_path_driving = path.name
         rosys.notify(f'Driving path {path.name}...', 'info')

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -151,13 +151,12 @@ class FieldCreator:
         assert self.first_row_start is not None
         assert self.first_row_end is not None
         assert self.last_row_end is not None
-        self.field.reference = self.first_row_start
         distance = self.first_row_end.distance(self.last_row_end)
         number_of_rows = distance / (self.row_spacing) + 1
         # get AB line
-        a = self.first_row_start.cartesian(self.field.reference)
-        b = self.first_row_end.cartesian(self.field.reference)
-        c = self.last_row_end.cartesian(self.field.reference)
+        a = self.first_row_start.cartesian()
+        b = self.first_row_end.cartesian()
+        c = self.last_row_end.cartesian()
         ab = a.direction(b)
         bc = b.direction(c)
         d = a.polar(distance, bc)
@@ -165,14 +164,14 @@ class FieldCreator:
             start = a.polar(i * self.row_spacing, bc)
             end = b.polar(i * self.row_spacing, bc)
             self.field.rows.append(Row(id=str(uuid4()), name=f'Row #{len(self.field.rows)}',
-                                       points=[self.field.reference.shifted(start),
-                                               self.field.reference.shifted(end)]
+                                       points=[self.first_row_start.shifted(start),
+                                               self.first_row_start.shifted(end)]
                                        ))
         bottom_left = a.polar(-self.padding_bottom, ab).polar(-self.padding, bc)
         top_left = b.polar(self.padding, ab).polar(-self.padding, bc)
         top_right = c.polar(self.padding, ab).polar(self.padding, bc)
         bottom_right = d.polar(-self.padding_bottom, ab).polar(self.padding, bc)
-        self.field.points = [self.field.reference.shifted(p) for p in [bottom_left, top_left, top_right, bottom_right]]
+        self.field.points = [self.first_row_start.shifted(p) for p in [bottom_left, top_left, top_right, bottom_right]]
         return 1 - number_of_rows % 1 < 0.1
 
     def _apply(self) -> None:

--- a/field_friend/interface/components/field_object.py
+++ b/field_friend/interface/components/field_object.py
@@ -1,7 +1,8 @@
 import numpy as np
 from nicegui.elements.scene_objects import Box, Curve, Cylinder, Extrusion, Group
 from rosys.geometry import Spline
-from ...automations import FieldProvider, Field
+
+from ...automations import Field, FieldProvider
 
 
 class field_object(Group):
@@ -42,7 +43,7 @@ class field_object(Group):
         [obj.delete() for obj in list(self.scene.objects.values()) if obj.name and obj.name.startswith('field_')]
         [obj.delete() for obj in list(self.scene.objects.values()) if obj.name and obj.name.startswith('obstacle_')]
         [obj.delete() for obj in list(self.scene.objects.values()) if obj.name and obj.name.startswith('row_')]
-        if active_field and active_field.reference is not None:
+        if active_field:
             field = active_field
             outline = [[point.x, point.y] for point in field.outline]
             if len(outline) > 1:  # Make sure there are at least two points to form a segment
@@ -51,17 +52,15 @@ class field_object(Group):
                     end = outline[(i + 1) % len(outline)]  # Loop back to the first point
                     self.create_fence(start, end)
 
-            if not field.reference:
-                return
             for obstacle in field.obstacles:
-                outline = [[point.x, point.y] for point in obstacle.cartesian(field.reference)]
+                outline = [[point.x, point.y] for point in obstacle.cartesian()]
                 Extrusion(outline, 0.1).with_name(f'obstacle_{obstacle.id}').material('#B80F0A')
 
             for row in field.rows:
                 if len(row.points) == 1:
                     continue
                 else:
-                    row_points = row.cartesian(field.reference)
+                    row_points = row.cartesian()
                     for i in range(len(row_points) - 1):
                         spline = Spline.from_points(row_points[i], row_points[i + 1])
                         Curve(

--- a/field_friend/interface/components/field_planner.py
+++ b/field_friend/interface/components/field_planner.py
@@ -44,7 +44,7 @@ class field_planner:
                     ui.button("Clear fields", on_click=self.field_provider.clear_fields).props("outline color=warning") \
                         .tooltip("Delete all fields").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
                     ui.button("Update reference", on_click=self.field_provider.update_reference).props("outline color=warning") \
-                        .tooltip("Delete all fields, set current position as geo reference and restart the system").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
+                        .tooltip("Set current position as geo reference and restart the system").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
             self.show_field_settings()
             self.show_object_settings()
             self.field_provider.FIELDS_CHANGED.register_ui(self.refresh_ui)

--- a/field_friend/interface/components/field_planner.py
+++ b/field_friend/interface/components/field_planner.py
@@ -1,11 +1,9 @@
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict
+from typing import TYPE_CHECKING, Literal, Optional, TypedDict
 
-import rosys
 from nicegui import events, ui
 
-from ...automations import Field, FieldObstacle, FieldProvider, Row
-from ...localization import Gnss
+from ...automations import Field, FieldObstacle, Row
 from .field_creator import FieldCreator
 from .leaflet_map import leaflet_map
 
@@ -40,10 +38,13 @@ class field_planner:
                         .classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
                     ui.button("Field Wizard", on_click=lambda: FieldCreator(system)).tooltip("Build a field with rows in a few simple steps") \
                         .classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
-                    ui.button("Clear fields", on_click=self.field_provider.clear_fields).props("outline color=warning") \
-                        .tooltip("Delete all fields").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
                 with ui.row().style("width: 100%;"):
                     self.show_field_table()
+                with ui.row():
+                    ui.button("Clear fields", on_click=self.field_provider.clear_fields).props("outline color=warning") \
+                        .tooltip("Delete all fields").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
+                    ui.button("Update reference", on_click=self.field_provider.update_reference).props("outline color=warning") \
+                        .tooltip("Delete all fields, set current position as geo reference and restart the system").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
             self.show_field_settings()
             self.show_object_settings()
             self.field_provider.FIELDS_CHANGED.register_ui(self.refresh_ui)

--- a/field_friend/interface/components/leaflet_map.py
+++ b/field_friend/interface/components/leaflet_map.py
@@ -80,8 +80,6 @@ class leaflet_map:
                 else:
                     with ui.dialog() as simulated_marker_dialog, ui.card():
                         ui.label('You are currently working in a simulation. What does the placed point represent?')
-                        ui.button('simulated roboter reference point',
-                                  on_click=lambda: self.set_simulated_reference(latlon, simulated_marker_dialog))
                         ui.button('as point for the current object',
                                   on_click=lambda: self.add_point_active_object(latlon, simulated_marker_dialog))
                         ui.button('Close', on_click=lambda: self.abort_point_drawing(simulated_marker_dialog))
@@ -111,19 +109,6 @@ class leaflet_map:
             .bind_enabled_from(self, 'active_field') \
             .props('icon=polyline dense flat') \
             .tooltip('center map on field boundaries').classes('ml-0')
-
-    def set_simulated_reference(self, latlon, dialog):
-        dialog.close()
-        self.m.remove_layer(self.drawn_marker)
-        self.gnss.reference = GeoPoint.from_list(latlon)
-        self.gnss.ROBOT_GNSS_POSITION_CHANGED.emit()
-        self.gnss.ROBOT_POSE_LOCATED.emit(rosys.geometry.Pose(
-            x=0.000,
-            y=0.000,
-            yaw=0.0,
-            time=0
-        ))
-        ui.notify(f'Robot reference has been set to {latlon[0]}, {latlon[1]}')
 
     def abort_point_drawing(self, dialog) -> None:
         if self.drawn_marker is not None:

--- a/field_friend/interface/components/status_dev.py
+++ b/field_friend/interface/components/status_dev.py
@@ -5,8 +5,17 @@ import psutil
 import rosys
 from nicegui import ui
 
-from ...hardware import (ChainAxis, FieldFriend, FieldFriendHardware, FlashlightPWMHardware, FlashlightPWMHardwareV2,
-                         Tornado, YAxis, ZAxis)
+from ... import localization
+from ...hardware import (
+    ChainAxis,
+    FieldFriend,
+    FieldFriendHardware,
+    FlashlightPWMHardware,
+    FlashlightPWMHardwareV2,
+    Tornado,
+    YAxis,
+    ZAxis,
+)
 
 if TYPE_CHECKING:
     from field_friend.system import System
@@ -298,7 +307,7 @@ def status_dev_page(robot: FieldFriend, system: 'System'):
             if robot.wheels.odrive_version == 4:
                 l0_status.text = 'cant read status update odrive to version 0.5.6'
         gnss_device_label.text = 'No connection' if system.gnss.device is None else 'Connected'
-        reference_position_label.text = 'No reference' if system.gnss.reference is None else 'Set'
+        reference_position_label.text = 'No reference' if localization.reference is None else 'Set'
         gnss_label.text = str(system.gnss.current.location) if system.gnss.current is not None else 'No position'
         heading_label.text = f'{system.gnss.current.heading:.2f}° {direction_flag}' if system.gnss.current is not None and system.gnss.current.heading is not None else 'No heading'
         rtk_fix_label.text = f'gps_qual: {system.gnss.current.gps_qual}, mode: {system.gnss.current.mode}' if system.gnss.current is not None else 'No fix'

--- a/field_friend/interface/components/status_drawer.py
+++ b/field_friend/interface/components/status_drawer.py
@@ -1,3 +1,4 @@
+from ... import localization
 from typing import TYPE_CHECKING
 
 import rosys
@@ -26,7 +27,6 @@ def status_drawer(system: 'System', robot: FieldFriend, gnss: Gnss, odometer: ro
                     ui.menu_item('Restart RoSys', on_click=system.restart)
                     if system.is_real:
                         ui.menu_item('Restart Lizard', on_click=system.field_friend.robot_brain.restart)
-                    ui.menu_item('Clear GNSS reference', on_click=system.gnss.clear_reference)
 
         ui.label('System Status').classes('text-xl')
 
@@ -232,7 +232,7 @@ def status_drawer(system: 'System', robot: FieldFriend, gnss: Gnss, odometer: ro
                 #         kpi_punches_label.text = system.kpi_provider.current_weeding_kpis.punches
 
             gnss_device_label.text = 'No connection' if gnss.device is None else 'Connected'
-            reference_position_label.text = 'No reference' if gnss.reference is None else 'Set'
+            reference_position_label.text = 'No reference' if localization.reference is None else 'Set'
             gnss_label.text = str(system.gnss.current.location) if system.gnss.current is not None else 'No position'
             heading_label.text = f'{system.gnss.current.heading:.2f}° {direction_flag}' if system.gnss.current is not None and system.gnss.current.heading is not None else 'No heading'
             rtk_fix_label.text = f'gps_qual: {system.gnss.current.gps_qual}, mode: {system.gnss.current.mode}' if system.gnss.current is not None else 'No fix'

--- a/field_friend/localization/__init__.py
+++ b/field_friend/localization/__init__.py
@@ -2,3 +2,6 @@ from .geo_point import GeoPoint, GeoPointCollection
 from .gnss import Gnss, GNSSRecord
 from .gnss_hardware import GnssHardware
 from .gnss_simulation import GnssSimulation
+
+
+reference: GeoPoint = GeoPoint(lat=0, long=0)

--- a/field_friend/localization/geo_point.py
+++ b/field_friend/localization/geo_point.py
@@ -8,6 +8,8 @@ import rosys
 import shapely
 from geographiclib.geodesic import Geodesic
 
+from .. import localization
+
 
 @dataclass(slots=True, kw_only=True)
 class GeoPoint:
@@ -26,15 +28,12 @@ class GeoPoint:
         geodetic_measurement = Geodesic.WGS84.Inverse(self.lat, self.long, other.lat, other.long)
         return geodetic_measurement['s12']
 
-    def cartesian(self, reference: GeoPoint) -> rosys.geometry.Point:
-        """Calculate the cartesian coordinates of this point relative to a reference point.
+    def cartesian(self) -> rosys.geometry.Point:
+        """Calculate the cartesian coordinates of this point relative to the reference point.
 
         This method uses the geodesic distance and azimuth angle between the reference point and
         the current point to calculate the Cartesian coordinates.
         The azimuth angle is measured clockwise from the north direction, and the resulting Cartesian coordinates have the x-axis to north and y-axis to west.
-
-        Parameters:
-        reference (GeoPoint): The reference GeoPoint to which the Cartesian coordinates are relative.
 
         Returns:
         rosys.geometry.Point: A Point object representing the Cartesian coordinates (x, y) 
@@ -42,7 +41,7 @@ class GeoPoint:
                             - x is the eastward distance in meters,
                             - y is the northward distance in meters.
         """
-        r = Geodesic.WGS84.Inverse(reference.lat, reference.long, self.lat, self.long)
+        r = Geodesic.WGS84.Inverse(localization.reference.lat, localization.reference.long, self.lat, self.long)
         s = r['s12']
         a = -np.deg2rad(r['azi1'])
         x = s * np.cos(a)
@@ -76,10 +75,10 @@ class GeoPointCollection:
     name: str
     points: list[GeoPoint] = field(default_factory=list)
 
-    def cartesian(self, reference: GeoPoint) -> list[rosys.geometry.Point]:
+    def cartesian(self) -> list[rosys.geometry.Point]:
         cartesian_points = []
         for point in self.points:
-            cartesian_points.append(point.cartesian(reference))
+            cartesian_points.append(point.cartesian())
         return cartesian_points
 
     @property

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -4,12 +4,12 @@ import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Optional, Protocol
+from typing import Optional
 
 import numpy as np
 import rosys
-import serial
 
+from .. import localization
 from .geo_point import GeoPoint
 from .point_transformation import get_new_position
 
@@ -47,41 +47,15 @@ class Gnss(ABC):
 
         self.current: Optional[GNSSRecord] = None
         self.device: str | None = None
-        self._reference: Optional[GeoPoint] = None
         self.antenna_offset = antenna_offset
 
         self.needs_backup = False
         rosys.on_repeat(self.update, 0.01)
         rosys.on_repeat(self.try_connection, 3.0)
 
-    @property
-    def reference(self) -> Optional[GeoPoint]:
-        return self._reference
-
-    @reference.setter
-    def reference(self, reference: GeoPoint) -> None:
-        assert reference is not None
-        if self._reference is not None:
-            relative_location_of_new_reference = reference.cartesian(self._reference)
-            new_position = self.odometer.prediction.point + relative_location_of_new_reference
-            self.odometer.history.clear()
-            self.odometer.prediction = rosys.geometry.Pose(x=new_position.x, y=new_position.y,
-                                                           yaw=self.odometer.prediction.yaw,
-                                                           time=rosys.time())
-        self._reference = reference
-
     @abstractmethod
     async def try_connection(self) -> None:
         pass
-
-    def clear_reference(self) -> None:
-        self.reference = None
-
-    def distance(self, point: GeoPoint) -> Optional[float]:
-        """Compute the distance between the reference point and the given point in meters"""
-        if self.reference is None:
-            return None
-        return point.distance(point)
 
     async def update(self) -> None:
         previous = deepcopy(self.current)
@@ -116,9 +90,9 @@ class Gnss(ABC):
 
     def _on_rtk_fix(self) -> None:
         assert self.current is not None
-        if self.reference is None:
+        if localization.reference.lat == 0 and localization.reference.long == 0:
             self.log.info(f'GNSS reference set to {self.current.location}')
-            self.reference = deepcopy(self.current.location)
+            localization.reference = deepcopy(self.current.location)
         if self.current.heading is not None:
             yaw = np.deg2rad(-self.current.heading)
         else:
@@ -126,7 +100,7 @@ class Gnss(ABC):
             yaw = self.odometer.get_pose(time=self.current.timestamp).yaw
         # correct the gnss coordinate by antenna offset
         self.current.location = get_new_position(self.current.location, self.antenna_offset, yaw+np.pi/2)
-        cartesian_coordinates = self.current.location.cartesian(self.reference)
+        cartesian_coordinates = self.current.location.cartesian()
         distance = self.odometer.prediction.point.distance(cartesian_coordinates)
         if distance > 1:
             self.log.warning(f'GNSS distance to prediction too high: {distance:.2f}m!!')

--- a/field_friend/localization/gnss_simulation.py
+++ b/field_friend/localization/gnss_simulation.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import rosys
 
+from .. import localization
 from .geo_point import GeoPoint
 from .gnss import Gnss, GNSSRecord
 
@@ -20,8 +21,10 @@ class GnssSimulation(Gnss):
 
     async def _create_new_record(self) -> Optional[GNSSRecord]:
         pose = self.wheels.pose
-        reference = self.reference if self.reference else GeoPoint(lat=51.983159, long=7.434212)
-        new_position = reference.shifted(pose.point)
+        if localization.reference.lat == 0 and localization.reference.long == 0:
+            new_position = GeoPoint(lat=51.983159, long=7.434212)
+        else:
+            new_position = localization.reference.shifted(pose.point)
         record = GNSSRecord(timestamp=pose.time, location=new_position)
         record.mode = "simulation"  # TODO check for possible values and replace "simulation"
         record.gps_qual = self.gps_quality

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -7,18 +7,42 @@ import psutil
 import rosys
 
 from . import localization
-from .automations import (AutomationWatcher, BatteryWatcher, FieldProvider, KpiProvider, PathProvider, PlantLocator,
-                          PlantProvider, Puncher)
-from .automations.implements import ChopAndScrew, Implement, Recorder, Tornado, WeedingScrew
-from .automations.navigation import (CoverageNavigation, FollowCropsNavigation, Navigation, RowsOnFieldNavigation,
-                                     StraightLineNavigation)
+from .automations import (
+    AutomationWatcher,
+    BatteryWatcher,
+    FieldProvider,
+    KpiProvider,
+    PathProvider,
+    PlantLocator,
+    PlantProvider,
+    Puncher,
+)
+from .automations.implements import (
+    ChopAndScrew,
+    Implement,
+    Recorder,
+    Tornado,
+    WeedingScrew,
+)
+from .automations.navigation import (
+    CoverageNavigation,
+    FollowCropsNavigation,
+    Navigation,
+    RowsOnFieldNavigation,
+    StraightLineNavigation,
+)
 from .hardware import FieldFriend, FieldFriendHardware, FieldFriendSimulation
 from .interface.components.info import Info
 from .kpi_generator import generate_kpis
 from .localization.geo_point import GeoPoint
 from .localization.gnss_hardware import GnssHardware
 from .localization.gnss_simulation import GnssSimulation
-from .vision import CalibratableUsbCameraProvider, CameraConfigurator, SimulatedCam, SimulatedCamProvider
+from .vision import (
+    CalibratableUsbCameraProvider,
+    CameraConfigurator,
+    SimulatedCam,
+    SimulatedCamProvider,
+)
 
 
 class System(rosys.persistence.PersistentModule):

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -6,47 +6,19 @@ import numpy as np
 import psutil
 import rosys
 
-from field_friend.hardware import (
-    FieldFriend,
-    FieldFriendHardware,
-    FieldFriendSimulation,
-)
-from field_friend.localization.gnss_hardware import GnssHardware
-from field_friend.localization.gnss_simulation import GnssSimulation
-from field_friend.vision import (
-    CalibratableUsbCameraProvider,
-    CameraConfigurator,
-    SimulatedCam,
-    SimulatedCamProvider,
-)
-
-from .automations import (
-    AutomationWatcher,
-    BatteryWatcher,
-    FieldProvider,
-    KpiProvider,
-    PathProvider,
-    PathRecorder,
-    PlantLocator,
-    PlantProvider,
-    Puncher,
-)
-from .automations.implements import (
-    ChopAndScrew,
-    Implement,
-    Recorder,
-    Tornado,
-    WeedingScrew,
-)
-from .automations.navigation import (
-    CoverageNavigation,
-    FollowCropsNavigation,
-    Navigation,
-    RowsOnFieldNavigation,
-    StraightLineNavigation,
-)
+from . import localization
+from .automations import (AutomationWatcher, BatteryWatcher, FieldProvider, KpiProvider, PathProvider, PlantLocator,
+                          PlantProvider, Puncher)
+from .automations.implements import ChopAndScrew, Implement, Recorder, Tornado, WeedingScrew
+from .automations.navigation import (CoverageNavigation, FollowCropsNavigation, Navigation, RowsOnFieldNavigation,
+                                     StraightLineNavigation)
+from .hardware import FieldFriend, FieldFriendHardware, FieldFriendSimulation
 from .interface.components.info import Info
 from .kpi_generator import generate_kpis
+from .localization.geo_point import GeoPoint
+from .localization.gnss_hardware import GnssHardware
+from .localization.gnss_simulation import GnssSimulation
+from .vision import CalibratableUsbCameraProvider, CameraConfigurator, SimulatedCam, SimulatedCamProvider
 
 
 class System(rosys.persistence.PersistentModule):
@@ -190,6 +162,8 @@ class System(rosys.persistence.PersistentModule):
         return {
             'navigation': self.current_navigation.name,
             'implement': self.current_implement.name,
+            'reference_lat': localization.reference.lat,
+            'reference_long': localization.reference.long,
         }
 
     def restore(self, data: dict[str, Any]) -> None:
@@ -199,6 +173,9 @@ class System(rosys.persistence.PersistentModule):
         navigation = self.navigation_strategies.get(data.get('navigation', None), None)
         if navigation is not None:
             self.current_navigation = navigation
+        lat = data.get('reference_lat', 0)
+        long = data.get('reference_long', 0)
+        localization.reference = GeoPoint(lat=lat, long=long)
 
     @property
     def current_implement(self) -> Implement:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,11 @@ import pytest
 import rosys
 from rosys.testing import forward, helpers
 
+from field_friend import localization
 from field_friend.automations import Field
 from field_friend.localization import GeoPoint, GnssSimulation
 from field_friend.system import System
+
 
 ROBOT_GEO_START_POSITION = GeoPoint(lat=51.983173401171236, long=7.434163443756093)
 
@@ -21,7 +23,7 @@ async def system(integration, request) -> AsyncGenerator[System, None]:
     s = System()
     assert isinstance(s.detector, rosys.vision.DetectorSimulation)
     s.detector.detection_delay = 0.1
-    s.gnss.reference = ROBOT_GEO_START_POSITION
+    localization.reference = ROBOT_GEO_START_POSITION
     helpers.odometer = s.odometer
     helpers.driver = s.driver
     helpers.automator = s.automator

--- a/tests/test_field_creator.py
+++ b/tests/test_field_creator.py
@@ -13,10 +13,8 @@ def test_geometry_computation(system: System):
     field_creator.first_row_start = GeoPoint(lat=51.98317071260942, long=7.43411239981148)
     field_creator.first_row_end = field_creator.first_row_start.shifted(Point(x=0, y=10))
     field_creator.last_row_end = field_creator.first_row_start.shifted(Point(x=10, y=10))
-    assert field_creator.field.reference is None
     assert field_creator.build_geometry()
     assert len(field_creator.field.rows) == 20
-    assert field_creator.field.reference == field_creator.first_row_start
     outline = field_creator.field.outline
     assert len(outline) == 4
     assert outline[0].x == pytest.approx(-field_creator.padding)

--- a/tests/test_field_creator.py
+++ b/tests/test_field_creator.py
@@ -1,15 +1,14 @@
 import pytest
-import rosys
 from rosys.geometry import Point
 
-from field_friend import System
-from field_friend.automations import Row
+from field_friend import System, localization
 from field_friend.interface.components.field_creator import FieldCreator
 from field_friend.localization import GeoPoint
 
 
 def test_geometry_computation(system: System):
     field_creator = FieldCreator(system)
+    localization.reference = GeoPoint(lat=51.98317071260942, long=7.43411239981148)
     field_creator.first_row_start = GeoPoint(lat=51.98317071260942, long=7.43411239981148)
     field_creator.first_row_end = field_creator.first_row_start.shifted(Point(x=0, y=10))
     field_creator.last_row_end = field_creator.first_row_start.shifted(Point(x=10, y=10))

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -15,9 +15,6 @@ def test_loading_from_old_persistence():
     assert len(field_provider.fields) == 3
     field = field_provider.fields[1]
     assert len(field.points) == 4
-    assert field.reference is not None
-    assert field.reference.lat == pytest.approx(51.98, rel=0.01)
-    assert field.reference.long == pytest.approx(7.43, rel=0.01)
     assert len(field.rows) == 2
     row = field.rows[1]
     assert len(row.points) == 2

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -22,7 +22,7 @@ def test_shifted_calculation():
     # coordinates should be x pointing north, y pointing west (verified with https://www.meridianoutpost.com/resources/etools/calculators/calculator-latitude-longitude-distance.php?)
     assert shifted.lat == pytest.approx(51.983212924295)
     assert shifted.long == pytest.approx(7.434124668461)
-    assert_point(shifted.cartesian(point), rosys.geometry.Point(x=6, y=6))
+    assert_point(shifted.cartesian(), rosys.geometry.Point(x=6, y=6))
 
 
 async def test_driving(gnss_driving: System):

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -1,4 +1,5 @@
 
+
 from copy import deepcopy
 
 import pytest
@@ -6,6 +7,7 @@ import rosys
 from conftest import ROBOT_GEO_START_POSITION
 from rosys.testing import assert_point, forward
 
+from field_friend import localization
 from field_friend.localization import GeoPoint, GnssSimulation
 from field_friend.system import System
 
@@ -18,6 +20,7 @@ def test_distance_calculation():
 
 def test_shifted_calculation():
     point = GeoPoint(lat=51.983159, long=7.434212)
+    localization.reference = deepcopy(point)
     shifted = point.shifted(rosys.geometry.Point(x=6, y=6))
     # coordinates should be x pointing north, y pointing west (verified with https://www.meridianoutpost.com/resources/etools/calculators/calculator-latitude-longitude-distance.php?)
     assert shifted.lat == pytest.approx(51.983212924295)
@@ -74,21 +77,3 @@ async def test_record_is_none(gnss_driving: System, gnss: GnssSimulation):
     await forward(5)
     # robot should have stopped driving
     assert_point(gnss_driving.odometer.prediction.point, rosys.geometry.Point(x=2, y=0))
-
-
-@pytest.mark.skip('does not work anymore due to gps using wheels.pose instead of odometry.pose')
-async def test_changing_reference(gnss_driving: System):
-    assert gnss_driving.gnss.current is not None
-    assert gnss_driving.gnss.reference is not None
-    assert gnss_driving.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
-    assert gnss_driving.gnss.reference.distance(ROBOT_GEO_START_POSITION) < 0.01
-    await forward(x=2.0, tolerance=0.001)
-    gnss_driving.automator.pause('changing reference point')
-    await forward(2)
-    assert gnss_driving.gnss.current.location.distance(ROBOT_GEO_START_POSITION) == pytest.approx(2.0, 0.1)
-    location = deepcopy(gnss_driving.gnss.current.location)
-    gnss_driving.gnss.reference = gnss_driving.gnss.reference.shifted(rosys.geometry.Point(x=-3.0, y=0.0))
-    await forward(2)
-    assert gnss_driving.odometer.prediction.point.x == pytest.approx(5.0)
-    assert gnss_driving.odometer.prediction.point.y == pytest.approx(0.0)
-    assert location == gnss_driving.gnss.current.location

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -119,21 +119,20 @@ async def test_follow_crops_with_slippage(system: System, detector: rosys.vision
     assert system.odometer.prediction.yaw_deg == pytest.approx(25.0, abs=2.0)
 
 
-@pytest.mark.skip('does not work anymore due to gps using wheels.pose instead of odometry.pose')
 async def test_approaching_first_row(system: System, field: Field):
     system.field_navigation.field = field
     system.current_navigation = system.field_navigation
     assert system.gnss.current
     assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
     system.automator.start()
-    await forward(x=1.5, y=-6.05)
+    await forward(until=lambda: system.field_navigation.state == system.field_navigation.State.APPROACHING_ROW_START)
+    await forward(1)
     assert system.field_navigation.current_row == field.rows[0]
-    assert system.field_navigation.state == system.field_navigation.State.APPROACHING_ROW_START
     assert system.field_navigation.automation_watcher.field_watch_active
     await forward(5)
     assert system.automator.is_running
     assert system.field_navigation.current_row == field.rows[0]
-    assert system.field_navigation.state == system.field_navigation.State.FOLLOWING_ROW
+    await forward(until=lambda: system.field_navigation.state == system.field_navigation.State.FOLLOWING_ROW)
     assert system.field_navigation.automation_watcher.field_watch_active
 
 


### PR DESCRIPTION
This pull request simplifies the handling of coordinates by replacing the per-field geo reference a global reference which is set once and never changes. This simplifies the code a lot and is less error-prone.

The reference can be changed by the press of a button in the Field Planner. It takes the current position of the robot as new reference and restarts the system (because all cartesian coordinates floating in memory needs to be recalculated according to the new reference point).

<img width="602" alt="Screenshot 2024-07-20 at 05 58 01" src="https://github.com/user-attachments/assets/8f595401-5697-4c88-aac3-93438b1b236c">

**ToDos**

- [x] test on real robot (with setting a new reference point after a field has been created)