### PR TITLE
fix WheelsSimulation parameter error with RoSys 0.11

### DIFF
--- a/field_friend/hardware/field_friend_simulation.py
+++ b/field_friend/hardware/field_friend_simulation.py
@@ -37,7 +37,7 @@ class FieldFriendSimulation(FieldFriend, rosys.hardware.RobotSimulation):
             self.CHOP_RADIUS = config_params['chop_radius']
         else:
             raise NotImplementedError(f'Unknown FieldFriend tool: {tool}')
-        wheels = rosys.hardware.WheelsSimulation(self.WHEEL_DISTANCE)
+        wheels = rosys.hardware.WheelsSimulation()
 
         y_axis: YAxisSimulation | ChainAxisSimulation | None
         if config_hardware['y_axis']['version'] == 'chain_axis':


### PR DESCRIPTION
when openig the simulation the error 
```
Traceback (most recent call last):
  File "/Users/johannes/Documents/Zauberzeug_repo/nicegui/nicegui/client.py", line 292, in safe_invoke
    result = func(self) if len(inspect.signature(func).parameters) == 1 else func()
                                                                             ^^^^^^
  File "/Users/johannes/Documents/Zauberzeug_repo/field_friend/main.py", line 29, in startup
    system = System()
             ^^^^^^^^
  File "/Users/johannes/Documents/Zauberzeug_repo/field_friend/field_friend/system.py", line 50, in __init__
    self.field_friend = FieldFriendSimulation(robot_id=self.version)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johannes/Documents/Zauberzeug_repo/field_friend/field_friend/hardware/field_friend_simulation.py", line 40, in __init__
    wheels = rosys.hardware.WheelsSimulation(self.WHEEL_DISTANCE)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: WheelsSimulation.__init__() takes 1 positional argument but 2 were given
2024-07-23 16:25:05.785 [ERROR] rosys/persistence/registry.py:58: failed to restore <field_friend.system.System object at 0x12fcf44d0>
Traceback (most recent call last):
  File "/Users/johannes/Documents/Zauberzeug_repo/rosys/rosys/persistence/registry.py", line 56, in restore
    module.restore(json.loads(filepath.read_text()))
  File "/Users/johannes/Documents/Zauberzeug_repo/field_friend/field_friend/system.py", line 168, in restore
    implement = self.implements.get(data.get('implement', None), None)
```
is thrown.

This is fixed by giving the correct arguments for WheelsSimulation init.