### PR TITLE
Remove nicegui from vscode workspace

### DIFF
--- a/field_friend.code-workspace
+++ b/field_friend.code-workspace
@@ -5,10 +5,6 @@
     },
     {
       "path": "../rosys"
-    },
-    {
-      "path": "../nicegui",
-      "name": "nicegui relative"
     }
   ],
   "settings": {},


### PR DESCRIPTION
We do not develop NiceGUI while working with the Field Friend.