### PR TITLE
Mode_indicator of GNS instead of the gps_qual from GGA sentence

### DIFF
--- a/field_friend/automations/automation_watcher.py
+++ b/field_friend/automations/automation_watcher.py
@@ -81,7 +81,7 @@ class AutomationWatcher:
     def try_resume(self) -> None:
         # Set conditions to True by default, which means they don't block the process if the watch is not active
         bumper_condition = not bool(self.field_friend.bumper.active_bumpers) if self.bumper_watch_active else True
-        gnss_condition = (self.gnss.current is not None and 'R' in self.gnss.current.mode) \
+        gnss_condition = (self.gnss.current is not None and ('R' in self.gnss.current.mode or self.gnss.current.mode == "SSSS")) \
             if self.gnss_watch_active else True
 
         # Enable automator only if all relevant conditions are True

--- a/field_friend/automations/automation_watcher.py
+++ b/field_friend/automations/automation_watcher.py
@@ -81,7 +81,7 @@ class AutomationWatcher:
     def try_resume(self) -> None:
         # Set conditions to True by default, which means they don't block the process if the watch is not active
         bumper_condition = not bool(self.field_friend.bumper.active_bumpers) if self.bumper_watch_active else True
-        gnss_condition = (self.gnss.current is not None and self.gnss.current.gps_qual == 4) \
+        gnss_condition = (self.gnss.current is not None and 'R' in self.gnss.current.mode) \
             if self.gnss_watch_active else True
 
         # Enable automator only if all relevant conditions are True

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -146,7 +146,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         if positioning is None or positioning.lat == 0 or positioning.long == 0:
             rosys.notify("No GNSS position.")
             return
-        if 'R' in self.gnss.current.mode:
+        if "R" in self.gnss.current.mode or self.gnss.current.mode == "SSSS":
             rosys.notify("GNSS position is not accurate enough.")
             return
         new_point = positioning
@@ -172,7 +172,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             if positioning is None or positioning.lat == 0 or positioning.long == 0:
                 rosys.notify("No GNSS position.")
                 return
-            if 'R' in self.gnss.current.mode:
+            if "R" in self.gnss.current.mode or self.gnss.current.mode == "SSSS":
                 rosys.notify("GNSS position is not accurate enough.")
                 return
             new_point = positioning
@@ -201,7 +201,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             if positioning is None or positioning.lat == 0 or positioning.long == 0:
                 rosys.notify("No GNSS position.")
                 return
-            if 'R' in self.gnss.current.mode:
+            if "R" in self.gnss.current.mode or self.gnss.current.mode == "SSSS":
                 rosys.notify("GNSS position is not accurate enough.")
                 return
             new_point = positioning

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -146,7 +146,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         if positioning is None or positioning.lat == 0 or positioning.long == 0:
             rosys.notify("No GNSS position.")
             return
-        if self.gnss.current.gps_qual != 4:
+        if 'R' in self.gnss.current.mode:
             rosys.notify("GNSS position is not accurate enough.")
             return
         new_point = positioning
@@ -172,7 +172,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             if positioning is None or positioning.lat == 0 or positioning.long == 0:
                 rosys.notify("No GNSS position.")
                 return
-            if self.gnss.current.gps_qual != 4:
+            if 'R' in self.gnss.current.mode:
                 rosys.notify("GNSS position is not accurate enough.")
                 return
             new_point = positioning
@@ -201,7 +201,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             if positioning is None or positioning.lat == 0 or positioning.long == 0:
                 rosys.notify("No GNSS position.")
                 return
-            if self.gnss.current.gps_qual != 4:
+            if 'R' in self.gnss.current.mode:
                 rosys.notify("GNSS position is not accurate enough.")
                 return
             new_point = positioning

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -67,7 +67,7 @@ class FieldCreator:
 
     def get_infos(self) -> None:
         assert self.gnss.current is not None
-        if self.gnss.current.gps_qual != 4:
+        if 'R' in self.gnss.current.mode:
             with self.content:
                 ui.label('No RTK fix available.').classes('text-red')
         self.first_row_start = self.gnss.current.location
@@ -103,7 +103,7 @@ class FieldCreator:
 
     def drive_to_last_row(self) -> None:
         assert self.gnss.current is not None
-        if self.gnss.current.gps_qual != 4:
+        if 'R' in self.gnss.current.mode:
             with self.content:
                 ui.label('No RTK fix available.').classes('text-red')
         self.first_row_end = self.gnss.current.location
@@ -119,7 +119,8 @@ class FieldCreator:
 
     def confirm_geometry(self) -> None:
         assert self.gnss.current is not None
-        if self.gnss.current.gps_qual != 4:
+        if 'R' in self.gnss.current.mode:
+        
             with self.content:
                 ui.label('No RTK fix available.').classes('text-red')
         self.last_row_end = self.gnss.current.location

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -67,7 +67,7 @@ class FieldCreator:
 
     def get_infos(self) -> None:
         assert self.gnss.current is not None
-        if 'R' in self.gnss.current.mode:
+        if "R" in self.gnss.current.mode or self.gnss.current.mode == "SSSS":
             with self.content:
                 ui.label('No RTK fix available.').classes('text-red')
         self.first_row_start = self.gnss.current.location
@@ -103,7 +103,7 @@ class FieldCreator:
 
     def drive_to_last_row(self) -> None:
         assert self.gnss.current is not None
-        if 'R' in self.gnss.current.mode:
+        if "R" in self.gnss.current.mode or self.gnss.current.mode == "SSSS":
             with self.content:
                 ui.label('No RTK fix available.').classes('text-red')
         self.first_row_end = self.gnss.current.location
@@ -119,8 +119,8 @@ class FieldCreator:
 
     def confirm_geometry(self) -> None:
         assert self.gnss.current is not None
-        if 'R' in self.gnss.current.mode:
-        
+        if "R" in self.gnss.current.mode or self.gnss.current.mode == "SSSS":
+
             with self.content:
                 ui.label('No RTK fix available.').classes('text-red')
         self.last_row_end = self.gnss.current.location

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -75,7 +75,7 @@ class Gnss(ABC):
                 self.log.warning('new GNSS record is None')
                 self.GNSS_CONNECTION_LOST.emit()
                 return
-            if previous.gps_qual == 4 and self.current.gps_qual != 4:
+            if ("R" in previous.mode or previous.mode == "SSSS") and ("R" not in self.current.mode and self.current.mode != "SSSS"):
                 self.log.warning('GNSS RTK fix lost')
                 self.ROBOT_GNSS_POSITION_CHANGED.emit(self.current.location)
                 self.RTK_FIX_LOST.emit()
@@ -85,7 +85,7 @@ class Gnss(ABC):
         try:
             # TODO also do antenna_offset correction for this event
             self.ROBOT_GNSS_POSITION_CHANGED.emit(self.current.location)
-            if "R" in self.current.mode:
+            if "R" in self.current.mode or self.current.mode == "SSSS":
                 self._on_rtk_fix()
         except Exception:
             self.log.exception('gnss record could not be applied')

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -85,7 +85,7 @@ class Gnss(ABC):
         try:
             # TODO also do antenna_offset correction for this event
             self.ROBOT_GNSS_POSITION_CHANGED.emit(self.current.location)
-            if self.current.gps_qual == 4:  # 4 = RTK fixed (cm accuracy), 5 = RTK float (dm accuracy)
+            if "R" in self.current.mode:
                 self._on_rtk_fix()
         except Exception:
             self.log.exception('gnss record could not be applied')

--- a/field_friend/localization/gnss_simulation.py
+++ b/field_friend/localization/gnss_simulation.py
@@ -14,6 +14,7 @@ class GnssSimulation(Gnss):
         self.wheels = wheels
         self.allow_connection = True
         self.gps_quality = 4
+        self.mode = 'SSSS'
 
     async def try_connection(self) -> None:
         if self.allow_connection:

--- a/field_friend/localization/gnss_simulation.py
+++ b/field_friend/localization/gnss_simulation.py
@@ -29,6 +29,7 @@ class GnssSimulation(Gnss):
         record = GNSSRecord(timestamp=pose.time, location=new_position)
         record.mode = "simulation"  # TODO check for possible values and replace "simulation"
         record.gps_qual = self.gps_quality
+        record.mode = self.mode
         await rosys.sleep(0.1)  # NOTE simulation does not be so fast and only eats a lot of cpu time
         return record
 

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -43,9 +43,17 @@ async def test_connection_lost(gnss_driving: System, gnss: GnssSimulation):
     await forward(3)
     # robot should have stopped driving
     assert_point(gnss_driving.odometer.prediction.point, rosys.geometry.Point(x=2.0, y=0))
-    gnss.gps_quality = 4
+    gnss.mode = "RRRR"
     await forward(5)
     # robot should continue driving
+    assert gnss_driving.odometer.prediction.point.x > 2.5
+
+
+async def test_simulated_rtk(gnss_driving: System, gnss: GnssSimulation):
+    await forward(x=2.0)
+    gnss.mode = 'SSSS'
+    assert_point(gnss_driving.odometer.prediction.point, rosys.geometry.Point(x=2.0, y=0))
+    await forward(5)
     assert gnss_driving.odometer.prediction.point.x > 2.5
 
 
@@ -55,7 +63,7 @@ async def test_rtk_lost(gnss_driving: System, gnss: GnssSimulation):
     await forward(3)
     # robot should have stopped driving
     assert_point(gnss_driving.odometer.prediction.point, rosys.geometry.Point(x=2.0, y=0))
-    gnss.mode = 'RFFF'
+    gnss.mode = "RFFF"
     await forward(5)
     # robot should continue driving
     assert gnss_driving.odometer.prediction.point.x > 2.5

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -39,7 +39,7 @@ async def test_driving(gnss_driving: System):
 
 async def test_connection_lost(gnss_driving: System, gnss: GnssSimulation):
     await forward(x=2.0)
-    gnss.gps_quality = 0
+    gnss.mode = 'NNNN'
     await forward(3)
     # robot should have stopped driving
     assert_point(gnss_driving.odometer.prediction.point, rosys.geometry.Point(x=2.0, y=0))
@@ -51,11 +51,11 @@ async def test_connection_lost(gnss_driving: System, gnss: GnssSimulation):
 
 async def test_rtk_lost(gnss_driving: System, gnss: GnssSimulation):
     await forward(x=2.0)
-    gnss.gps_quality = 5
+    gnss.mode = 'FFFF'
     await forward(3)
     # robot should have stopped driving
     assert_point(gnss_driving.odometer.prediction.point, rosys.geometry.Point(x=2.0, y=0))
-    gnss.gps_quality = 4
+    gnss.mode = 'RFFF'
     await forward(5)
     # robot should continue driving
     assert gnss_driving.odometer.prediction.point.x > 2.5


### PR DESCRIPTION
The GNSS module sends information formatted along the NMEA-0183 standard. We are currently using the Lat/Lon position from the [GNS message](https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_GNS.html) which contains GNSS data. For data quality checks we are further using the gps_qual of the [GGA massage](https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_GGA.html) which only refers to GPS. The mode_indicator of the GNS message contains the mode of every single satellite system. 

Todo:

- [x] use the mode_indicator instead of the gps_qual
- [x]  check, if it is enough if a single satellite system gives RTK fixed data (e.g. mode: 'RNNN) or if all need to be fixes (mode: 'RRRR') to get RTX-fixed LatLon positions
- [x] test on a robot