### PR TITLE
Add support for icecream

### DIFF
--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any
 
+import icecream
 import numpy as np
 import psutil
 import rosys
@@ -44,6 +45,7 @@ from .vision import (
     SimulatedCamProvider,
 )
 
+icecream.install()
 
 class System(rosys.persistence.PersistentModule):
 


### PR DESCRIPTION
In the next RoSys release, icecream is not installed anymore by default. This PR makes icecream available in the Field Friend code again.