### PR TITLE
Allow recording weeding action in timelapse video

### DIFF
--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -24,6 +24,7 @@ from .vision import CalibratableUsbCameraProvider, CameraConfigurator, Simulated
 
 icecream.install()
 
+
 class System(rosys.persistence.PersistentModule):
 
     version = 'unknown'  # This is set in main.py through the environment variable VERSION or ROBOT_ID
@@ -121,6 +122,10 @@ class System(rosys.persistence.PersistentModule):
         self.automator = rosys.automation.Automator(self.steerer, on_interrupt=self.field_friend.stop)
         self.automation_watcher = AutomationWatcher(self)
         self.monitoring = Recorder(self)
+        self.timelapse_recorder = rosys.analysis.TimelapseRecorder()
+        self.timelapse_recorder.frame_info_builder = lambda _: f'{self.version}, {self.current_navigation.name}, tags: {", ".join(self.plant_locator.tags)}'
+        rosys.NEW_NOTIFICATION.register(self.timelapse_recorder.notify)
+        rosys.on_startup(self.timelapse_recorder.compress_video)  # NOTE: cleanup JPEGs from before last shutdown
         self.field_navigation = RowsOnFieldNavigation(self, self.monitoring)
         self.straight_line_navigation = StraightLineNavigation(self, self.monitoring)
         self.follow_crops_navigation = FollowCropsNavigation(self, self.monitoring)

--- a/main.py
+++ b/main.py
@@ -3,12 +3,13 @@ import os
 
 from dotenv import load_dotenv
 from nicegui import app, ui
-from rosys.analysis import logging_page
+from rosys.analysis import logging_page, videos_page
 
 import field_friend.log_configuration as log_configuration
 from field_friend import interface
 from field_friend.interface.components import header_bar, status_drawer, system_bar
 from field_friend.system import System
+
 
 logger = log_configuration.configure()
 app.add_static_files('/assets', 'assets')
@@ -46,6 +47,7 @@ def startup() -> None:
         return {'status': 'ok'}
 
     logging_page(['field_friend', 'rosys'])  # /logging
+    videos_page()  # /videos
 
 
 app.on_startup(startup)


### PR DESCRIPTION
This PR allows the recording of timelapse videos for weeding implements. The videos are made available through the `/videos` url path.

**ToDos**

- [ ] test on real robot and ensure the video compression does not disturb operation of the robot
- [ ] provide link to `/videos` page?