### PR TITLE
Follow Crops: drive straight without crops

### DIFF
--- a/field_friend/automations/navigation/follow_crops_navigation.py
+++ b/field_friend/automations/navigation/follow_crops_navigation.py
@@ -7,13 +7,13 @@ from nicegui import ui
 from rosys.helpers import eliminate_2pi
 
 from ..implements.implement import Implement
-from .navigation import Navigation
+from .straight_line_navigation import StraightLineNavigation
 
 if TYPE_CHECKING:
     from system import System
 
 
-class FollowCropsNavigation(Navigation):
+class FollowCropsNavigation(StraightLineNavigation):
     CROP_ATTRACTION: float = 0.3
 
     def __init__(self, system: 'System', tool: Implement) -> None:
@@ -41,6 +41,15 @@ class FollowCropsNavigation(Navigation):
         self.plant_locator.pause()
         await self.implement.deactivate()
 
+    def get_origin(self) -> rosys.geometry.Point:
+        return self.odometer.prediction.point
+
+    def get_target(self) -> rosys.geometry.Point:
+        distance = self.length - self.odometer.prediction.point.distance(self.start_position)
+        print(f'distance: {distance}')
+        target = self.odometer.prediction.transform(rosys.geometry.Point(x=distance, y=0))
+        return target
+
     async def _drive(self, distance: float) -> None:
         row = self.plant_provider.get_relevant_crops(self.odometer.prediction.point, max_distance=1.0)
         if len(row) >= 3:
@@ -56,9 +65,11 @@ class FollowCropsNavigation(Navigation):
             fitted_line = rosys.geometry.Line(a=m, b=-1, c=c)
             closest_point = fitted_line.foot_point(self.odometer.prediction.point)
             target = rosys.geometry.Pose(x=closest_point.x, y=closest_point.y, yaw=yaw)
+            await self._drive_towards_target(distance, target)
         else:
-            target = self.odometer.prediction
-        await self._drive_towards_target(distance, target)
+            self.origin = self.get_origin()
+            self.target = self.get_target()
+            await super()._drive(distance)
 
     def combine_angles(self, angle1: float, influence: float, angle2: float) -> float:
         weight1 = influence
@@ -79,22 +90,13 @@ class FollowCropsNavigation(Navigation):
             p = self.odometer.prediction.transform3d(p)
             self.detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='maize', position=p))
 
-    def _should_finish(self) -> bool:
-        distance = self.odometer.prediction.point.distance(self.start_position)
-        if distance < 0.5:
-            return False  # at least drive 0.5m
-        if len(self.plant_provider.get_relevant_crops(self.odometer.prediction.point)) == 0:
-            self.log.info('No crops in sight -- stopping navigation')
-            return True
-        return False
-
     def settings_ui(self) -> None:
+        super().settings_ui()
         ui.number('Crop Attraction', step=0.1, min=0.0, max=1.0, format='%.1f', on_change=self.request_backup) \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'crop_attraction') \
-            .tooltip(f'Influence of the crop row direction on the driving direction (default: {self.crop_attraction:.1f})')
-        super().settings_ui()
+            .tooltip(f'Influence of the crop row direction on the driving direction (default: {self.CROP_ATTRACTION:.1f})')
 
     def backup(self) -> dict:
         return super().backup() | {

--- a/field_friend/automations/navigation/follow_crops_navigation.py
+++ b/field_friend/automations/navigation/follow_crops_navigation.py
@@ -41,14 +41,10 @@ class FollowCropsNavigation(StraightLineNavigation):
         self.plant_locator.pause()
         await self.implement.deactivate()
 
-    def get_origin(self) -> rosys.geometry.Point:
-        return self.odometer.prediction.point
-
-    def get_target(self) -> rosys.geometry.Point:
+    def update_target(self) -> None:
+        self.origin = self.odometer.prediction.point
         distance = self.length - self.odometer.prediction.point.distance(self.start_position)
-        print(f'distance: {distance}')
-        target = self.odometer.prediction.transform(rosys.geometry.Point(x=distance, y=0))
-        return target
+        self.target = self.odometer.prediction.transform(rosys.geometry.Point(x=distance, y=0))
 
     async def _drive(self, distance: float) -> None:
         row = self.plant_provider.get_relevant_crops(self.odometer.prediction.point, max_distance=1.0)
@@ -67,8 +63,7 @@ class FollowCropsNavigation(StraightLineNavigation):
             target = rosys.geometry.Pose(x=closest_point.x, y=closest_point.y, yaw=yaw)
             await self._drive_towards_target(distance, target)
         else:
-            self.origin = self.get_origin()
-            self.target = self.get_target()
+            self.update_target()
             await super()._drive(distance)
 
     def combine_angles(self, angle1: float, influence: float, angle2: float) -> float:

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -44,6 +44,7 @@ class Navigation(rosys.persistence.PersistentModule):
             if not await self.prepare():
                 self.log.error('Preparation failed')
                 return
+            await self.gnss.update_robot_pose()
             self.start_position = self.odometer.prediction.point
             if isinstance(self.driver.wheels, rosys.hardware.WheelsSimulation) and not rosys.is_test:
                 self.create_simulation()

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -35,13 +35,19 @@ class StraightLineNavigation(Navigation):
         await super().finish()
         await self.implement.deactivate()
 
+    def get_origin(self) -> rosys.geometry.Point:
+        return self.origin
+
+    def get_target(self) -> rosys.geometry.Point:
+        return self.target
+
     async def _drive(self, distance: float) -> None:
         start_position = self.odometer.prediction.point
         closest_point = rosys.geometry.Line.from_points(self.origin, self.target).foot_point(start_position)
         yaw = closest_point.direction(self.target)
         await self._drive_towards_target(distance, rosys.geometry.Pose(x=closest_point.x, y=closest_point.y, yaw=yaw))
 
-    def _should_finish(self) -> None:
+    def _should_finish(self) -> bool:
         end_pose = rosys.geometry.Pose(x=self.target.x, y=self.target.y, yaw=self.origin.direction(self.target), time=0)
         return end_pose.relative_point(self.odometer.prediction.point).x > 0
 
@@ -61,12 +67,12 @@ class StraightLineNavigation(Navigation):
                                                                                     position=rosys.geometry.Point3d(x=p.x, y=p.y, z=0)))
 
     def settings_ui(self) -> None:
+        super().settings_ui()
         ui.number('Length', step=0.5, min=0.05, format='%.1f', on_change=self.request_backup) \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'length') \
             .tooltip('Length to drive in meters')
-        super().settings_ui()
 
     def backup(self) -> dict:
         return super().backup() | {

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -26,8 +26,7 @@ class StraightLineNavigation(Navigation):
     async def prepare(self) -> bool:
         await super().prepare()
         self.log.info(f'Activating {self.implement.name}...')
-        self.origin = self.odometer.prediction.point
-        self.target = self.odometer.prediction.transform(rosys.geometry.Point(x=self.length, y=0))
+        self.update_target()
         await self.implement.activate()
         return True
 
@@ -35,11 +34,9 @@ class StraightLineNavigation(Navigation):
         await super().finish()
         await self.implement.deactivate()
 
-    def get_origin(self) -> rosys.geometry.Point:
-        return self.origin
-
-    def get_target(self) -> rosys.geometry.Point:
-        return self.target
+    def update_target(self) -> None:
+        self.origin = self.odometer.prediction.point
+        self.target = self.odometer.prediction.transform(rosys.geometry.Point(x=self.length, y=0))
 
     async def _drive(self, distance: float) -> None:
         start_position = self.odometer.prediction.point


### PR DESCRIPTION
Before, follow crops stopped when no crops were detected. Now follow crops extends straight line and continues to drive the remaining distance in a straight line from the last crop pose.

ToDo:
- [x] Adapt tests
- [x] Test on real robot
- [x] Think about the `get_origin` and `get_target` functions
- [x] Check `RowsOnFieldNavigation` since it extends `FollowCropsNavigation`

The tests for `RowsOnFieldNavigation` work for now, but I didnt check them further