### PR TITLE
Distanced Reference Warning Dialog

### DIFF
--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -4,8 +4,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import rosys
+from geographiclib.geodesic import Geodesic
 from nicegui import ui
 
+from ... import localization
 from ..implements import Implement
 
 if TYPE_CHECKING:
@@ -26,6 +28,7 @@ class Navigation(rosys.persistence.PersistentModule):
         self.log = logging.getLogger('field_friend.navigation')
         self.driver = system.driver
         self.odometer = system.odometer
+        self.field_provider = system.field_provider
         self.gnss = system.gnss
         self.kpi_provider = system.kpi_provider
         self.plant_provider = system.plant_provider
@@ -46,6 +49,9 @@ class Navigation(rosys.persistence.PersistentModule):
                 self.log.error('Preparation failed')
                 return
             await self.gnss.update_robot_pose()
+            if self.gnss.current.location.distance(localization.reference) > 2000.0:
+                self.reference_alert_dialog.open()
+                return
             self.start_position = self.odometer.prediction.point
             if isinstance(self.driver.wheels, rosys.hardware.WheelsSimulation) and not rosys.is_test:
                 self.create_simulation()
@@ -132,6 +138,12 @@ class Navigation(rosys.persistence.PersistentModule):
         pass
 
     def settings_ui(self) -> None:
+        with ui.dialog() as self.reference_alert_dialog, ui.card():
+            ui.label('The reference is to far away from the current position which would lead to issues in the navigation. Do you want to set it now?')
+            with ui.row():
+                ui.button("Update reference", on_click=self.field_provider.update_reference).props("outline color=warning") \
+                    .tooltip("Set current position as geo reference and restart the system").classes("ml-auto").style("display: block; margin-top:auto; margin-bottom: auto;")
+                ui.button('Cancel', on_click=self.reference_alert_dialog.close)
         ui.number('Linear Speed', step=0.01, min=0.01, max=1.0, format='%.2f', on_change=self.request_backup) \
             .props('dense outlined') \
             .classes('w-24') \


### PR DESCRIPTION
To prevent a robot that changes its location and does not receive a current reference from having errors/inaccuracies in its work, it should be checked at the start of an automation whether the reference is x km away from the field.

The user is informed by a pop-up that the reference should be reset.