### PR TITLE
Improved GNSS pausing

### DIFF
--- a/field_friend/automations/automation_watcher.py
+++ b/field_friend/automations/automation_watcher.py
@@ -39,7 +39,6 @@ class AutomationWatcher:
 
         rosys.on_repeat(self.try_resume, 0.1)
         rosys.on_repeat(self.check_field_bounds, 1.0)
-        rosys.on_repeat(self.ensure_robot_pose_updates_when_not_in_automation, 5.0)
         if self.field_friend.bumper:
             self.field_friend.bumper.BUMPER_TRIGGERED.register(lambda name: self.pause(f'Bumper {name} was triggered'))
         self.gnss.GNSS_CONNECTION_LOST.register(lambda: self.pause('GNSS connection lost'))
@@ -123,15 +122,3 @@ class AutomationWatcher:
                 self.stop('robot is outside of field boundaries')
                 self.field_watch_active = False
 
-    async def ensure_robot_pose_updates_when_not_in_automation(self) -> None:
-        if self.automator.is_running:
-            return
-        if self.gnss.is_paused:
-            self.log.warning('GNSS is paused, this should not happen outside of an automation')
-            self.gnss.is_paused = False
-            return
-        if self.last_robot_pose == self.odometer.prediction:
-            await self.gnss.update_robot_pose()
-        else:
-            self.gnss.observed_poses.clear()
-        self.last_robot_pose = self.odometer.prediction

--- a/field_friend/automations/navigation/a_b_line_navigation.py
+++ b/field_friend/automations/navigation/a_b_line_navigation.py
@@ -51,7 +51,6 @@ class ABLineNavigation(Navigation):
         if not len(self.row.points) >= 2:
             rosys.notify(f'Row {self.row.name} on field {self.field.name} has not enough points', 'negative')
             return False
-        self.gnss.is_paused = False
         await rosys.sleep(3)  # wait for GNSS to update
         self.automation_watcher.start_field_watch(self.field.outline)
 

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -51,13 +51,13 @@ class Navigation(rosys.persistence.PersistentModule):
             self.log.info('Navigation started')
             while not self._should_finish():
                 distance = await self.implement.get_stretch(self.MAX_STRETCH_DISTANCE)
-                if distance > self.MAX_STRETCH_DISTANCE:  # we do not want to drive to long without observing
+                if distance > self.MAX_STRETCH_DISTANCE:  # No crop in sight
                     await self._drive(self.DEFAULT_DRIVE_DISTANCE)
-                else:
-                    await self._drive(distance)
+                else: # Crop in sight
                     with self.gnss.paused(): # Pause GNSS for better local accuracy
-                        await self.implement.start_workflow()
-                        await self.implement.stop_workflow()
+                        await self._drive(distance)
+                    await self.implement.start_workflow()
+                    await self.implement.stop_workflow()
         except WorkflowException as e:
             self.kpi_provider.increment_weeding_kpi('automation_stopped')
             self.log.error(f'WorkflowException: {e}')

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -77,7 +77,7 @@ class Navigation(rosys.persistence.PersistentModule):
         self.log.info('clearing plant provider')
 
         self.log.info('waiting for GNSS pose upsate')
-        await self.gnss.wait_for_updated_robot_pose()
+        await self.gnss.wait_for_robot_pose_update(timeout = 10)
         return True
 
     async def finish(self) -> None:

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -75,6 +75,9 @@ class Navigation(rosys.persistence.PersistentModule):
         if isinstance(self.detector, rosys.vision.DetectorSimulation) and not rosys.is_test:
             self.detector.simulated_objects = []
         self.log.info('clearing plant provider')
+
+        self.log.info('waiting for GNSS pose upsate')
+        await self.gnss.wait_for_updated_robot_pose()
         return True
 
     async def finish(self) -> None:

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -55,7 +55,7 @@ class Navigation(rosys.persistence.PersistentModule):
                     await self._drive(self.DEFAULT_DRIVE_DISTANCE)
                 else:
                     await self._drive(distance)
-                    with self.gnss.pause(): # Pause GNSS for better local accuracy
+                    with self.gnss.paused(): # Pause GNSS for better local accuracy
                         await self.implement.start_workflow()
                         await self.implement.stop_workflow()
         except WorkflowException as e:

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -53,7 +53,6 @@ class Navigation(rosys.persistence.PersistentModule):
                 distance = await self.implement.get_stretch(self.MAX_STRETCH_DISTANCE)
                 if distance > self.MAX_STRETCH_DISTANCE:  # we do not want to drive to long without observing
                     await self._drive(self.DEFAULT_DRIVE_DISTANCE)
-                    continue
                 else:
                     await self._drive(distance)
                     with self.gnss.pause(): # Pause GNSS for better local accuracy

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -55,8 +55,8 @@ class Navigation(rosys.persistence.PersistentModule):
                     await self._drive(self.DEFAULT_DRIVE_DISTANCE)
                     continue
                 else:
-                    with self.gnss.paused(): # Pause GNSS for better local accuracy
-                        await self._drive(distance)
+                    await self._drive(distance)
+                    with self.gnss.pause(): # Pause GNSS for better local accuracy
                         await self.implement.start_workflow()
                         await self.implement.stop_workflow()
         except WorkflowException as e:

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -145,14 +145,15 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         
         try:
             self.ROBOT_POSE_LOCATED.register(callback)
-            if timeout is None:
-                await event.wait()
-            else:
-                await asyncio.wait_for(event.wait(), timeout=timeout)
+            try:
+                if timeout is None:
+                    await event.wait()
+                else:
+                    await asyncio.wait_for(event.wait(), timeout=timeout)
+            finally:
+                self.ROBOT_POSE_LOCATED.unregister(callback)
         except asyncio.TimeoutError:
             raise TimeoutError(f"Timed out waiting for robot pose update after {timeout} seconds")
-        finally:
-            self.ROBOT_POSE_LOCATED.unregister(callback)
 
     def _update_robot_pose(self) -> None:
         x = np.mean([pose.point.x for pose in self.observed_poses])

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -134,6 +134,7 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
             self._update_robot_pose()
 
     async def wait_for_updated_robot_pose(self) -> None:
+        assert not self._is_paused
         if self.ensure_gnss:
             await self._pose_update.wait()
 

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -4,7 +4,8 @@ import contextlib
 import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from dataclasses import datacfrom from typing import Any, Optional
+from dataclasses import dataclass
+from typing import Any, Optional
 
 import numpy as np
 import rosys

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -56,7 +56,6 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         self.observed_poses: list[rosys.geometry.Pose] = []
         self.last_pose_update = rosys.time()
         self.needed_poses: int = self.NEEDED_POSES
-        self.min_seconds_between_updates: float = self.MIN_SECONDS_BETWEEN_UPDATES
         self.ensure_gnss: bool = self.ENSURE_GNSS
 
         self.needs_backup = False

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -152,8 +152,8 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
                     await asyncio.wait_for(event.wait(), timeout=timeout)
             finally:
                 self.ROBOT_POSE_LOCATED.unregister(callback)
-        except asyncio.TimeoutError:
-            raise TimeoutError(f"Timed out waiting for robot pose update after {timeout} seconds")
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(f"Timed out waiting for robot pose update after {timeout} seconds") from e
 
     def _update_robot_pose(self) -> None:
         x = np.mean([pose.point.x for pose in self.observed_poses])

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -95,7 +95,7 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
             self.current = None
 
     @contextlib.contextmanager
-    def pause(self):
+    def paused(self):
         try:
             self._is_paused = True
             yield
@@ -129,7 +129,6 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         if len(self.observed_poses) > self.needed_poses: # Ensure fresh data
             self.observed_poses.pop(0)
         
-        # Only update if unpaused
         if not self._is_paused:
             self._update_robot_pose()
 

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import rosys
@@ -24,7 +24,7 @@ class GNSSRecord:
     gps_qual: int = 0
     altitude: float = 0.0
     separation: float = 0.0
-    heading: Optional[float] = None
+    heading: float | None = None
     speed_kmh: float = 0.0
 
 
@@ -49,7 +49,7 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         self.GNSS_CONNECTION_LOST = rosys.event.Event()
         """the GNSS connection was lost"""
 
-        self.current: Optional[GNSSRecord] = None
+        self.current: GNSSRecord | None = None
         self.device: str | None = None
         self.antenna_offset = antenna_offset
         self._is_paused = False
@@ -107,7 +107,7 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         return self._is_paused
 
     @abstractmethod
-    async def _create_new_record(self) -> Optional[GNSSRecord]:
+    async def _create_new_record(self) -> GNSSRecord | None:
         pass
 
     def _on_rtk_fix(self) -> None:
@@ -136,7 +136,7 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         if not self._is_paused:
             self._update_robot_pose()
 
-    async def wait_for_robot_pose_update(self, timeout: Optional[float] = None) -> None:
+    async def wait_for_robot_pose_update(self, timeout: float | None = None) -> None:
         event = asyncio.Event()
         def callback():
             nonlocal event

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -29,7 +29,6 @@ class GNSSRecord:
 
 class Gnss(rosys.persistence.PersistentModule, ABC):
     NEEDED_POSES: int = 10
-    MIN_SECONDS_BETWEEN_UPDATES: float = 10.0
     ENSURE_GNSS: bool = False
 
     def __init__(self, odometer: rosys.driving.Odometer, antenna_offset: float) -> None:

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -136,7 +136,7 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         if not self._is_paused:
             self._update_robot_pose()
 
-    async def wait_for_robot_pose_update(self, timeout = None) -> None:
+    async def wait_for_robot_pose_update(self, timeout : Optional[float] = None) -> None:
         event = asyncio.Event()
         def callback():
             nonlocal event

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -161,8 +161,6 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         yaw = np.mean([pose.yaw for pose in self.observed_poses])
         pose = rosys.geometry.Pose(x=float(x), y=float(y), yaw=float(yaw), time=rosys.time())
         self.ROBOT_POSE_LOCATED.emit(pose)
-        self._pose_update.set()
-        self._pose_update.clear()
         self.last_pose_update = rosys.time()
         self.observed_poses.clear()
 

--- a/field_friend/localization/gnss.py
+++ b/field_friend/localization/gnss.py
@@ -136,7 +136,7 @@ class Gnss(rosys.persistence.PersistentModule, ABC):
         if not self._is_paused:
             self._update_robot_pose()
 
-    async def wait_for_robot_pose_update(self, timeout : Optional[float] = None) -> None:
+    async def wait_for_robot_pose_update(self, timeout: Optional[float] = None) -> None:
         event = asyncio.Event()
         def callback():
             nonlocal event


### PR DESCRIPTION
Hello,

This PR contains an improved method for pausing the GNSS during fine adjusting of the robot when approaching a crop.
Instead of relying on an external task to constantly check if the GNSS is unpaused, the GNSS is paused by use of a contextmanager, which is more clear and is safer in case of unexpected failures.

There is also an improvement on how GNSS data is handled: The amount of points to average over is set and stale data gets discarded ensuring, that we don't accidentally average over data from a long drive.

There might be some considerations for when exactly to pause the GNSS, but as of this PR, all fine adjustment with the GNSS paused happens in the puncher class.
