### PR TITLE
Fixing Point3d in camera_card and plant_object

### DIFF
--- a/field_friend/interface/components/camera_card.py
+++ b/field_friend/interface/components/camera_card.py
@@ -219,8 +219,8 @@ class camera_card:
     def build_svg_for_plant_provider(self) -> str:
         if self.camera is None or self.camera.calibration is None:
             return ''
-        position = rosys.geometry.Point(x=self.camera.calibration.extrinsics.translation[0],
-                                        y=self.camera.calibration.extrinsics.translation[1])
+        position = rosys.geometry.Point3d(x=self.camera.calibration.extrinsics.translation[0],
+                                          y=self.camera.calibration.extrinsics.translation[1])
         svg = ''
         for plant in self.plant_provider.get_relevant_weeds(position):
             position_3d = rosys.geometry.Point3d(x=plant.position.x, y=plant.position.y, z=0)

--- a/field_friend/interface/components/plant_object.py
+++ b/field_friend/interface/components/plant_object.py
@@ -18,7 +18,7 @@ class plant_objects(Group):
         self.plant_provider.PLANTS_CHANGED.register_ui(self.update)
 
     def update(self) -> None:
-        origin = rosys.geometry.Point(x=0, y=0)
+        origin = rosys.geometry.Point3d(x=0, y=0, z=0)
         in_world = {p.id: p for p in
                     self.plant_provider.get_relevant_weeds(origin, max_distance=1000) +
                     self.plant_provider.get_relevant_crops(origin, max_distance=1000)}


### PR DESCRIPTION
During simulation two errors arrows where a Point was used instead of a Point3d. This is connected to #169 