### PR TITLE
Update to rosys 0.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ geopy
 shapely
 fiona
 geopandas
-rosys == v0.15.1
+rosys == v0.16.1
 uvicorn == 0.28.1


### PR DESCRIPTION
Rosys 0.16.1 is now released!

Release notes:
[0.16.0](https://github.com/zauberzeug/rosys/releases/tag/v0.16.0)
[0.16.1](https://github.com/zauberzeug/rosys/releases/tag/v0.16.1)