### PR TITLE
Fix gnss navigation bug 

### DIFF
--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -82,6 +82,7 @@ class Navigation(rosys.persistence.PersistentModule):
         if isinstance(self.detector, rosys.vision.DetectorSimulation) and not rosys.is_test:
             self.detector.simulated_objects = []
         self.log.info('clearing plant provider')
+        await self.gnss.update_robot_pose()
         return True
 
     async def finish(self) -> None:

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -34,6 +34,7 @@ async def test_straight_line_with_high_angles(system: System):
     await system.driver.wheels.stop()
     assert isinstance(system.current_navigation, StraightLineNavigation)
     system.current_navigation.length = 1.0
+    system.gnss.observed_poses.clear()
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
     await forward(until=lambda: system.automator.is_stopped)


### PR DESCRIPTION
We had driving timeouts when starting an automation the first time, because the target position was set before the robot updated it's position. This PR fixes that.