### PR TITLE
field_provider.py mutable default argument

### DIFF
--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -53,7 +53,9 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.request_backup()
         self.FIELDS_CHANGED.emit()
 
-    def create_field(self, points: list[GeoPoint] = []) -> Field:
+    def create_field(self, points: list[GeoPoint] | None = None) -> Field:
+        if points is None:
+            points = []
         new_id = str(uuid.uuid4())
         field = Field(id=f'{new_id}', name=f'field_{len(self.fields)+1}', points=points)
         self.fields.append(field)
@@ -70,7 +72,9 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.FIELDS_CHANGED.emit()
         self.invalidate()
 
-    def create_obstacle(self, field: Field, points: list[GeoPoint] = []) -> FieldObstacle:
+    def create_obstacle(self, field: Field, points: list[GeoPoint] | None = None) -> FieldObstacle:
+        if points is None:
+            points = []
         obstacle = FieldObstacle(id=f'{str(uuid.uuid4())}', name=f'obstacle_{len(field.obstacles)+1}', points=points)
         field.obstacles.append(obstacle)
         self.invalidate()
@@ -80,7 +84,9 @@ class FieldProvider(rosys.persistence.PersistentModule):
         field.obstacles.remove(obstacle)
         self.invalidate()
 
-    def create_row(self, field: Field, points: list[GeoPoint] = []) -> Row:
+    def create_row(self, field: Field, points: list[GeoPoint] | None = None) -> Row:
+        if points is None:
+            points = []
         row = Row(id=f'{str(uuid.uuid4())}', name=f'row_{len(field.rows)+1}', points=points)
         field.rows.append(row)
         self.invalidate()

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 import rosys
 from geographiclib.geodesic import Geodesic
@@ -138,7 +138,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.fields[field_index].rows = sorted(field.rows, key=lambda row: get_distance(row, direction=direction))
         self.FIELDS_CHANGED.emit()
 
-    async def add_field_point(self, field: Field, point: Optional[GeoPoint] = None, new_point: Optional[GeoPoint] = None) -> None:
+    async def add_field_point(self, field: Field, point: GeoPoint | None = None, new_point: GeoPoint | None = None) -> None:
         assert self.gnss.current is not None
         positioning = self.gnss.current.location
         if positioning is None or positioning.lat == 0 or positioning.long == 0:
@@ -155,7 +155,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             field.points.append(new_point)
         self.invalidate()
 
-    def remove_field_point(self, field: Field, point: Optional[GeoPoint] = None) -> None:
+    def remove_field_point(self, field: Field, point: GeoPoint | None = None) -> None:
         if point is not None:
             index = field.points.index(point)
             del field.points[index]
@@ -163,7 +163,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             del field.points[-1]
         self.invalidate()
 
-    def add_obstacle_point(self, field: Field, obstacle: FieldObstacle, point: Optional[GeoPoint] = None, new_point: Optional[GeoPoint] = None) -> None:
+    def add_obstacle_point(self, field: Field, obstacle: FieldObstacle, point: GeoPoint | None = None, new_point: GeoPoint | None = None) -> None:
         if new_point is None:
             assert self.gnss.current is not None
             positioning = self.gnss.current.location
@@ -181,7 +181,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             obstacle.points.append(new_point)
         self.invalidate()
 
-    def remove_obstacle_point(self, obstacle: FieldObstacle, point: Optional[GeoPoint] = None) -> None:
+    def remove_obstacle_point(self, obstacle: FieldObstacle, point: GeoPoint | None = None) -> None:
         if obstacle.points:
             if point is not None:
                 index = obstacle.points.index(point)
@@ -190,7 +190,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
                 del obstacle.points[-1]
             self.invalidate()
 
-    def add_row_point(self, field: Field, row: Row, point: Optional[GeoPoint] = None, new_point: Optional[GeoPoint] = None) -> None:
+    def add_row_point(self, field: Field, row: Row, point: GeoPoint | None = None, new_point: GeoPoint | None = None) -> None:
         if new_point is None:
             assert self.gnss.current is not None
             positioning = self.gnss.current.location
@@ -208,7 +208,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             row.points.append(new_point)
         self.invalidate()
 
-    def remove_row_point(self, row: Row, point: Optional[GeoPoint] = None) -> None:
+    def remove_row_point(self, row: Row, point: GeoPoint | None = None) -> None:
         if row.points:
             if point is not None:
                 index = row.points.index(point)


### PR DESCRIPTION
Hello,

in the FieldProvider class, there are multiple instances of mutable default arguments.
I have observed, that when using the FieldFriend and creating a field, adding more than one row results in the rows sharing the same points until restarted.
The root cause are mutable default arguments (the list of points given when calling create_row as example), which are then referenced in 2 different instances of Row. When restarting the the program, the rows are restored from a file, in which case, the list of points are instantiated seperately (fixing this shared reference).

The fix is to simply change the function to explicitly create a new list, when no argument is supplied.