### PR TITLE
Speedup tornado workflow by moving axis during driving.

### DIFF
--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -1,4 +1,6 @@
 
+import asyncio
+
 from collections import deque
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +23,49 @@ class Tornado(WeedingImplement):
         self.drill_between_crops: bool = False
         self.field_friend = system.field_friend
 
+        self.move_y_while_driving = False
+        self.move_knifes_while_driving = False
+
+        self.y_axis_move_task = None
+        self.knife_reset_task = None
+
+    async def _reset_knifes(self) -> None:
+        await self.field_friend.z_axis.turn_knifes_to(0)
+        await rosys.sleep(0.5)
+        await self.field_friend.z_axis.turn_knifes_to(self.tornado_angle)
+
+    async def finish(self) -> None:
+        await super().finish()
+        if self.y_axis_move_task:
+            try:
+                self.y_axis_move_task.cancel()
+                self.y_axis_move_task = None
+            except:
+                pass
+        if self.knife_reset_task:
+            try:
+                self.knife_reset_task.cancel()
+                self.knife_reset_task = None
+            except:
+                pass
+        await self.field_friend.z_axis.turn_knifes_to(0)
+
+    async def prepare(self) -> None:
+        res = await super().prepare()
+        if self.y_axis_move_task:
+            try:
+                self.y_axis_move_task.cancel()
+                self.y_axis_move_task = None
+            except:
+                res = False
+        if self.knife_reset_task:
+            try:
+                self.knife_reset_task.cancel()
+                self.knife_reset_task = None
+            except:
+                res = False
+        return res
+
     async def start_workflow(self) -> None:
         await super().start_workflow()
         self.log.info('Performing Tornado Workflow..')
@@ -33,7 +78,24 @@ class Tornado(WeedingImplement):
             open_drill = False
             if self.drill_with_open_tornado:
                 open_drill = True
+
+            if self.y_axis_move_task:
+                await self.y_axis_move_task
+                if self.y_axis_move_task.exception():
+                    raise self.y_axis_move_task.exception()
+                self.y_axis_move_task = None
+
+            if self.knife_reset_task:
+                await self.knife_reset_task
+                if self.knife_reset_task.exception():
+                    raise self.knife_reset_task.exception()
+                self.knife_reset_task = None
+
             await self.system.puncher.punch(y=self.next_punch_y_position, angle=self.tornado_angle, with_open_tornado=open_drill)
+            if self.move_knifes_while_driving:
+                self.knife_reset_task = asyncio.create_task(self._reset_knifes())
+            else:
+                await self._reset_knifes()
             # TODO remove weeds from plant_provider and increment kpis (like in Weeding Screw)
             if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
                 # remove the simulated weeds
@@ -81,6 +143,8 @@ class Tornado(WeedingImplement):
             stretch = 0
         if stretch < max_distance:
             self.next_punch_y_position = closest_crop_position.y
+            if self.move_y_while_driving:
+                self.y_axis_move_task = asyncio.create_task(self.field_friend.y_axis.move_to(self.next_punch_y_position))
             return stretch
         return self.WORKING_DISTANCE
 
@@ -121,6 +185,9 @@ class Tornado(WeedingImplement):
         ui.checkbox('Demo Mode') \
             .bind_value(self.puncher, 'is_demo') \
             .tooltip('If active, stop right before the ground')
+        
+        ui.checkbox("Move y while driving").bind_value(self, 'move_y_while_driving').tooltip("Moves the y-axis into position whilst driving.")
+        ui.checkbox("Move knifes while driving").bind_value(self, 'move_knifes_while_driving').tooltip("Moves the knifes into the correct angle whilst driving.")
         # TODO test and reactivate these options
         # ui.checkbox('Drill 2x with open tornado') \
         #     .bind_value(self, 'drill_with_open_tornado') \

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -153,20 +153,14 @@ class Puncher:
             await self.field_friend.z_axis.move_down_until_reference(min_position=-0.058 if self.is_demo else None)
 
             await self.field_friend.z_axis.turn_knifes_to(angle)
-            await rosys.sleep(2)
             await self.field_friend.z_axis.turn_by(turns)
-            await rosys.sleep(2)
 
             if with_open_drill:
                 self.log.info('Drilling again with open drill...')
                 await self.field_friend.z_axis.turn_knifes_to(0)
-                await rosys.sleep(2)
                 await self.field_friend.z_axis.turn_by(turns)
-                await rosys.sleep(2)
 
             await self.field_friend.z_axis.return_to_reference()
-            await rosys.sleep(0.5)
-            await self.field_friend.z_axis.turn_knifes_to(0)
             await rosys.sleep(0.5)
         except Exception as e:
             raise PuncherException(f'tornado drill failed because of: {e}') from e

--- a/field_friend/hardware/tornado.py
+++ b/field_friend/hardware/tornado.py
@@ -234,11 +234,11 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
                 f'{self.name}_knife_stop_enabled = true;'
                 f'{self.name}_knife_ground_enabled = true;'
             )
-            await rosys.sleep(0.5)
+            await rosys.sleep(0.2)
             await self.robot_brain.send(
                 f'{self.name}_z.position({min_position}, {self.speed_limit}, 0);'
             )
-            await rosys.sleep(0.5)
+            await rosys.sleep(0.2)
             while self.ref_knife_ground and not self.ref_knife_stop:
                 if min_position - 0.005 <= self.position_z <= min_position + 0.005:
                     self.log.info('minimum position reached')

--- a/field_friend/hardware/y_axis_canopen_hardware.py
+++ b/field_friend/hardware/y_axis_canopen_hardware.py
@@ -73,14 +73,16 @@ class YAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware):
             self.log.error(f'could not move yaxis to {position} because of {error}')
             raise Exception(f'could not move yaxis to {position} because of {error}')
         steps = self.compute_steps(position)
+        if steps == self.steps:
+            return # Already at steps
         self.log.info(f'moving to steps: {steps}')
         await self.enable_motor()
-        await rosys.sleep(1)  # necessary ?!
+        await rosys.sleep(0.2)  # necessary ?!
         await self.robot_brain.send(
             f'{self.name}.position({steps},{speed}, 0);'
         )
         # Give flags time to turn false first
-        await rosys.sleep(0.5)
+        await rosys.sleep(0.2)
         while not self.idle and not self.alarm:
             await rosys.sleep(0.2)
         if self.alarm:


### PR DESCRIPTION
Hello,

This PR contains changes to generally speed up the tornado workflow aswell as allow the y-axis and tornado angle to be adjusted whilst approaching the next crop.

For some background:
The current speed of a tornado workflow is around 30-35 seconds. 5 seconds are from adjusting the tornado angle and another 1-2 seconds come from the y-axis moving.
This change would optimally save 7 seconds per workflow. For 10 000 plants this mounts up to 20 hours of time saved (optimally).

There are still some considerations to be had about handling errors and correctly canceling the axis movement, but it is in a working state.