### PR TITLE
Update Rosys to v0.17.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ geopy
 shapely
 fiona
 geopandas
-rosys == v0.16.1
+rosys == v0.17.1
 uvicorn == 0.28.1


### PR DESCRIPTION
[v0.17.0](https://github.com/zauberzeug/rosys/releases/tag/v0.17.0)
[v0.17.1](https://github.com/zauberzeug/rosys/releases/tag/v0.17.1)