### PR TITLE
Field Navigation GNSS Fix

### DIFF
--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -71,6 +71,7 @@ class FieldNavigation(FollowCropsNavigation):
         self.plant_provider.clear()
 
         self.automation_watcher.start_field_watch(self.field.outline)
+        self.automation_watcher.gnss_watch_active = True
 
         self.log.info(f'Activating {self.implement.name}...')
         await self.implement.activate()
@@ -82,6 +83,7 @@ class FieldNavigation(FollowCropsNavigation):
     async def finish(self) -> None:
         await super().finish()
         self.automation_watcher.stop_field_watch()
+        self.automation_watcher.gnss_watch_active = False
         await self.implement.deactivate()
 
     def get_nearest_row(self) -> Row:


### PR DESCRIPTION
While testing the Field Navigation we observed small GNSS connection losses that led to Driving Timeoutes, why the automation should stop when GNSS signal is lost 