### PR TITLE
Rework turning after row

### DIFF
--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -145,6 +145,8 @@ class FieldNavigation(FollowCropsNavigation):
         await self.driver.drive_to(self.start_point)
         await self.gnss.ROBOT_POSE_LOCATED.emitted(self._max_gnss_waiting_time)
         # turn to row
+        assert self.start_point is not None
+        assert self.end_point is not None
         row_yaw = self.start_point.direction(self.end_point)
         await self.turn_in_steps(row_yaw)
 

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import rosys
-import rosys.helpers
 from nicegui import ui
 from rosys.geometry import Point
 


### PR DESCRIPTION
Before the robot was turning in fixed steps without adjusting the steps in between.
This PR solves this, but we have to test if the robot wiggles around the target heading when it overshoots just a little.