### PR TITLE
Field with Beds

### DIFF
--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -135,7 +135,6 @@ class Field:
                     base_offset = row_in_bed * self.row_spacing
                     bed_offset = bed_index * ((self.row_count - 1) * self.row_spacing + self.bed_spacing)
                     offset = base_offset + bed_offset
-
             offset_row_coordinated = offset_curve(ab_line_cartesian, -offset).coords
             row_points: list[GeoPoint] = [localization.reference.shifted(
                 Point(x=p[0], y=p[1])) for p in offset_row_coordinated]

--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -47,17 +47,17 @@ class Field:
                  first_row_start: GeoPoint,
                  first_row_end: GeoPoint,
                  row_spacing: float = 0.5,
-                 row_number: int = 10,
+                 row_count: int = 10,
                  outline_buffer_width: float = 2,
                  row_support_points: list[RowSupportPoint] | None = None,
                  bed_count: int = 1,
-                 bed_spacing: float | None = 0.5) -> None:
+                 bed_spacing: float = 0.5) -> None:
         self.id: str = id
         self.name: str = name
         self.first_row_start: GeoPoint = first_row_start
         self.first_row_end: GeoPoint = first_row_end
         self.row_spacing: float = row_spacing
-        self.row_number: int = row_number  # rows per bed
+        self.row_count: int = row_count  # rows per bed
         self.bed_count: int = bed_count
         self.bed_spacing: float = bed_spacing if bed_spacing is not None else row_spacing * 2
         self.outline_buffer_width: float = outline_buffer_width
@@ -90,7 +90,7 @@ class Field:
     def worked_area(self, worked_rows: int) -> float:
         worked_area = 0.0
         if self.area() > 0:
-            total_rows = self.row_number * self.bed_count
+            total_rows = self.row_count * self.bed_count
             worked_area = worked_rows * self.area() / total_rows
         return worked_area
 
@@ -107,10 +107,10 @@ class Field:
         last_support_point = None
         last_support_point_offset = 0
 
-        total_rows = int(self.row_number * self.bed_count)
+        total_rows = int(self.row_count * self.bed_count)
         for i in range(total_rows):
-            bed_index = i // self.row_number
-            row_in_bed = i % self.row_number
+            bed_index = i // self.row_count
+            row_in_bed = i % self.row_count
 
             support_point = next((sp for sp in self.row_support_points if sp.row_index == i), None)
             if support_point:
@@ -124,7 +124,7 @@ class Field:
                     offset = last_support_point_offset + (i - last_support_point.row_index) * self.row_spacing
                 else:
                     base_offset = row_in_bed * self.row_spacing
-                    bed_offset = bed_index * (self.row_number * self.row_spacing + self.bed_spacing)
+                    bed_offset = bed_index * (self.row_count * self.row_spacing + self.bed_spacing)
                     offset = base_offset + bed_offset
 
             offset_row_coordinated = offset_curve(ab_line_cartesian, -offset).coords
@@ -156,7 +156,7 @@ class Field:
             'first_row_start':  rosys.persistence.to_dict(self.first_row_start),
             'first_row_end': rosys.persistence.to_dict(self.first_row_end),
             'row_spacing': self.row_spacing,
-            'row_number': self.row_number,
+            'row_count': self.row_count,
             'outline_buffer_width': self.outline_buffer_width,
             'row_support_points': [rosys.persistence.to_dict(sp) for sp in self.row_support_points],
             'bed_count': self.bed_count,

--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -107,7 +107,7 @@ class Field:
         last_support_point = None
         last_support_point_offset = 0
 
-        total_rows = int(self.row_count * self.bed_count)
+        total_rows = self.row_count * self.bed_count
         for i in range(total_rows):
             bed_index = i // self.row_count
             row_in_bed = i % self.row_count

--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -121,10 +121,19 @@ class Field:
                 last_support_point_offset = offset
             else:
                 if last_support_point:
-                    offset = last_support_point_offset + (i - last_support_point.row_index) * self.row_spacing
+                    rows_since_support = i - last_support_point.row_index
+                    beds_crossed = bed_index - (last_support_point.row_index // self.row_count)
+                    offset = last_support_point_offset
+                    if beds_crossed > 0:
+                        offset += beds_crossed * self.bed_spacing
+                        rows_in_complete_beds = rows_since_support - (row_in_bed + 1)
+                        offset += rows_in_complete_beds * self.row_spacing
+                        offset += row_in_bed * self.row_spacing
+                    else:
+                        offset += rows_since_support * self.row_spacing
                 else:
                     base_offset = row_in_bed * self.row_spacing
-                    bed_offset = bed_index * (self.row_count * self.row_spacing + self.bed_spacing)
+                    bed_offset = bed_index * ((self.row_count - 1) * self.row_spacing + self.bed_spacing)
                     offset = base_offset + bed_offset
 
             offset_row_coordinated = offset_curve(ab_line_cartesian, -offset).coords

--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -49,13 +49,17 @@ class Field:
                  row_spacing: float = 0.5,
                  row_number: int = 10,
                  outline_buffer_width: float = 2,
-                 row_support_points: list[RowSupportPoint] | None = None) -> None:
+                 row_support_points: list[RowSupportPoint] | None = None,
+                 bed_count: int = 1,
+                 bed_spacing: float | None = 0.5) -> None:
         self.id: str = id
         self.name: str = name
         self.first_row_start: GeoPoint = first_row_start
         self.first_row_end: GeoPoint = first_row_end
         self.row_spacing: float = row_spacing
-        self.row_number: int = row_number
+        self.row_number: int = row_number  # rows per bed
+        self.bed_count: int = bed_count
+        self.bed_spacing: float = bed_spacing if bed_spacing is not None else row_spacing * 2
         self.outline_buffer_width: float = outline_buffer_width
         self.row_support_points: list[RowSupportPoint] = row_support_points or []
         self.row_support_points.sort(key=lambda sp: sp.row_index)
@@ -86,7 +90,8 @@ class Field:
     def worked_area(self, worked_rows: int) -> float:
         worked_area = 0.0
         if self.area() > 0:
-            worked_area = worked_rows * self.area() / self.row_number
+            total_rows = self.row_number * self.bed_count
+            worked_area = worked_rows * self.area() / total_rows
         return worked_area
 
     def refresh(self):
@@ -102,7 +107,11 @@ class Field:
         last_support_point = None
         last_support_point_offset = 0
 
-        for i in range(int(self.row_number)):
+        total_rows = int(self.row_number * self.bed_count)
+        for i in range(total_rows):
+            bed_index = i // self.row_number
+            row_in_bed = i % self.row_number
+
             support_point = next((sp for sp in self.row_support_points if sp.row_index == i), None)
             if support_point:
                 support_point_cartesian = support_point.cartesian()
@@ -114,7 +123,10 @@ class Field:
                 if last_support_point:
                     offset = last_support_point_offset + (i - last_support_point.row_index) * self.row_spacing
                 else:
-                    offset = i * self.row_spacing
+                    base_offset = row_in_bed * self.row_spacing
+                    bed_offset = bed_index * (self.row_number * self.row_spacing + self.bed_spacing)
+                    offset = base_offset + bed_offset
+
             offset_row_coordinated = offset_curve(ab_line_cartesian, -offset).coords
             row_points: list[GeoPoint] = [localization.reference.shifted(
                 Point(x=p[0], y=p[1])) for p in offset_row_coordinated]
@@ -147,6 +159,8 @@ class Field:
             'row_number': self.row_number,
             'outline_buffer_width': self.outline_buffer_width,
             'row_support_points': [rosys.persistence.to_dict(sp) for sp in self.row_support_points],
+            'bed_count': self.bed_count,
+            'bed_spacing': self.bed_spacing,
         }
 
     def shapely_polygon(self) -> shapely.geometry.Polygon:

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -71,9 +71,6 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.fields.clear()
         self.invalidate()
 
-    def clear_selected_beds(self) -> None:
-        self.selected_beds.clear()
-
     def delete_selected_field(self) -> None:
         if not self.selected_field:
             self.log.warning('No field selected. Nothing was deleted.')
@@ -123,6 +120,9 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.log.info('Updated parameters for field %s: row number = %d, row spacing = %f',
                       field.name, row_count, row_spacing)
         self.invalidate()
+
+    def clear_selected_beds(self) -> None:
+        self.selected_beds = []
 
     def get_rows_to_work_on(self) -> list[Row]:
         rows_to_work_on: list[Row] = []

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -3,7 +3,7 @@ import logging
 import rosys
 
 from ..localization import Gnss
-from . import Field, RowSupportPoint, Row
+from . import Field, Row, RowSupportPoint
 
 
 class FieldProvider(rosys.persistence.PersistentModule):
@@ -125,16 +125,16 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.selected_beds = []
 
     def get_rows_to_work_on(self) -> list[Row]:
-        rows_to_work_on: list[Row] = []
         if not self.selected_field:
             self.log.warning('No field selected. Cannot get rows to work on.')
-            return rows_to_work_on
-        if self.selected_field.bed_count > 1 and len(self.selected_beds) > 0:
-            row_indices = []
-            for bed in self.selected_beds:
-                for number in range(int(self.selected_field.row_count)):
-                    row_indices.append((bed - 1) * int(self.selected_field.row_count) + number)
-            rows_to_work_on = [row for i, row in enumerate(self.selected_field.rows) if i in row_indices]
-        else:
-            rows_to_work_on = self.selected_field.rows
-        return rows_to_work_on
+            return []
+        if self.selected_field.bed_count == 1:
+            return self.selected_field.rows
+        if len(self.selected_beds) == 0:
+            self.log.warning('No beds selected. Cannot get rows to work on.')
+            return []
+        row_indices = []
+        for bed in self.selected_beds:
+            for row_index in range(self.selected_field.row_count):
+                row_indices.append((bed - 1) * self.selected_field.row_count + row_index)
+        return [row for i, row in enumerate(self.selected_field.rows) if i in row_indices]

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -95,17 +95,17 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.selected_field = self.get_field(id_)
         self.FIELD_SELECTED.emit()
 
-    def update_field_parameters(self, field_id: str, name: str, row_number: int, row_spacing: float, outline_buffer_width: float, bed_count: int, bed_spacing: float) -> None:
+    def update_field_parameters(self, field_id: str, name: str, row_count: int, row_spacing: float, outline_buffer_width: float, bed_count: int, bed_spacing: float) -> None:
         field = self.get_field(field_id)
         if not field:
             self.log.warning('Field with id %s not found. Cannot update parameters.', field_id)
             return
         field.name = name
-        field.row_number = row_number
+        field.row_count = row_count
         field.row_spacing = row_spacing
         field.bed_count = bed_count
         field.bed_spacing = bed_spacing
         field.outline_buffer_width = outline_buffer_width
         self.log.info('Updated parameters for field %s: row number = %d, row spacing = %f',
-                      field.name, row_number, row_spacing)
+                      field.name, row_count, row_spacing)
         self.invalidate()

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -23,6 +23,8 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.FIELD_SELECTED = rosys.event.Event()
         """A field has been selected."""
 
+        self.selected_beds: list[int] = []
+
     def backup(self) -> dict:
         return {
             'fields': {f.id: f.to_dict() for f in self.fields},
@@ -45,6 +47,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.FIELDS_CHANGED.emit()
         if self.selected_field and self.selected_field not in self.fields:
             self.selected_field = None
+            self.selected_beds = []
             self.FIELD_SELECTED.emit()
 
     def get_field(self, id_: str | None) -> Field | None:
@@ -59,6 +62,9 @@ class FieldProvider(rosys.persistence.PersistentModule):
     def clear_fields(self) -> None:
         self.fields.clear()
         self.invalidate()
+
+    def clear_selected_beds(self) -> None:
+        self.selected_beds.clear()
 
     def delete_selected_field(self) -> None:
         if not self.selected_field:

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -95,7 +95,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.selected_field = self.get_field(id_)
         self.FIELD_SELECTED.emit()
 
-    def update_field_parameters(self, field_id: str, name: str, row_number: int, row_spacing: float, outline_buffer_width: float) -> None:
+    def update_field_parameters(self, field_id: str, name: str, row_number: int, row_spacing: float, outline_buffer_width: float, bed_count: int, bed_spacing: float) -> None:
         field = self.get_field(field_id)
         if not field:
             self.log.warning('Field with id %s not found. Cannot update parameters.', field_id)
@@ -103,6 +103,8 @@ class FieldProvider(rosys.persistence.PersistentModule):
         field.name = name
         field.row_number = row_number
         field.row_spacing = row_spacing
+        field.bed_count = bed_count
+        field.bed_spacing = bed_spacing
         field.outline_buffer_width = outline_buffer_width
         self.log.info('Updated parameters for field %s: row number = %d, row spacing = %f',
                       field.name, row_number, row_spacing)

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -134,7 +134,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
             for bed in self.selected_beds:
                 for number in range(int(self.selected_field.row_count)):
                     row_indices.append((bed - 1) * int(self.selected_field.row_count) + number)
-            self.rows_to_work_on = [row for i, row in enumerate(self.selected_field.rows) if i in row_indices]
+            rows_to_work_on = [row for i, row in enumerate(self.selected_field.rows) if i in row_indices]
         else:
-            self.rows_to_work_on = self.selected_field.rows
+            rows_to_work_on = self.selected_field.rows
         return rows_to_work_on

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -62,15 +62,8 @@ class FieldNavigation(FollowCropsNavigation):
         if self.field is None:
             rosys.notify('No field selected', 'negative')
             return False
-        if self.field.bed_count > 1 and len(self.field_provider.selected_beds) > 0:
-            row_indices = []
-            for bed in self.field_provider.selected_beds:
-                for number in range(int(self.field.row_count)):
-                    row_indices.append((bed - 1) * int(self.field.row_count) + number)
-            self.rows_to_work_on = [row for i, row in enumerate(self.field.rows) if i in row_indices]
-        else:
-            self.rows_to_work_on = self.field.rows
-        if not self.rows_to_work_on:
+        self.rows_to_work_on = self.field_provider.get_rows_to_work_on()
+        if not self.rows_to_work_on or len(self.rows_to_work_on) == 0:
             rosys.notify('No rows available', 'negative')
             return False
         if self.gnss.device is None:

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -24,7 +24,7 @@ class FieldCreator:
         self.first_row_end: GeoPoint | None = None
         self.field_name: str = 'Field'
         self.row_spacing: float = 0.5
-        self.row_number: int = 10
+        self.row_count: int = 10
         self.outline_buffer_width: float = 2.0
         self.bed_number: int = 1
         self.bed_spacing: float = 0.5
@@ -88,7 +88,7 @@ class FieldCreator:
                       value=10, step=1, min=1) \
                 .props('dense outlined').classes('w-40') \
                 .tooltip('Set the number of rows.')\
-                .bind_value(self, 'row_number')
+                .bind_value(self, 'row_count')
             ui.number('Row Spacing', suffix='cm',
                       value=50, step=1, min=1) \
                 .props('dense outlined').classes('w-40') \
@@ -130,7 +130,7 @@ class FieldCreator:
                     ui.label(f'Number of Beds: {self.bed_number}').classes('text-lg')
                     ui.label(f'Bed Spacing: {self.bed_spacing*100} cm').classes('text-lg')
                 ui.label(f'Row Spacing: {self.row_spacing*100} cm').classes('text-lg')
-                ui.label(f'Number of Rows: {self.row_number}').classes('text-lg')
+                ui.label(f'Number of Rows: {self.row_count}').classes('text-lg')
                 ui.label(f'Outline Buffer Width: {self.outline_buffer_width} m').classes('text-lg')
             with ui.row().classes('items-center'):
                 ui.button('Cancel', on_click=self.dialog.close).props('color=red')
@@ -147,7 +147,7 @@ class FieldCreator:
                                                    first_row_start=self.first_row_start,
                                                    first_row_end=self.first_row_end,
                                                    row_spacing=self.row_spacing,
-                                                   row_number=self.row_number,
+                                                   row_count=self.row_count,
                                                    outline_buffer_width=self.outline_buffer_width,
                                                    bed_count=self.bed_number,
                                                    bed_spacing=self.bed_spacing))
@@ -157,7 +157,7 @@ class FieldCreator:
                                                    first_row_start=self.first_row_start,
                                                    first_row_end=self.first_row_end,
                                                    row_spacing=self.row_spacing,
-                                                   row_number=self.row_number,
+                                                   row_count=self.row_count,
                                                    outline_buffer_width=self.outline_buffer_width))
         self.first_row_start = None
         self.first_row_end = None

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -26,7 +26,7 @@ class FieldCreator:
         self.row_spacing: float = 0.5
         self.row_count: int = 10
         self.outline_buffer_width: float = 2.0
-        self.bed_number: int = 1
+        self.bed_count: int = 1
         self.bed_spacing: float = 0.5
         self.next: Callable = self.find_first_row
 
@@ -37,7 +37,7 @@ class FieldCreator:
                     self.headline = ui.label().classes('text-lg font-bold')
                     self.content = ui.column().classes('items-center')
                     # NOTE: the next function is replaced, hence we need the lambda
-                    ui.button('Next', on_click=lambda: self.next())
+                    ui.button('Next', on_click=lambda: self.next())  # pylint: disable=unnecessary-lambda
         ui.timer(0.1, self.update_front_cam)
         self.open()
 
@@ -77,7 +77,7 @@ class FieldCreator:
                       value=10, step=1, min=1) \
                 .props('dense outlined').classes('w-40') \
                 .tooltip('Set the number of beds.')\
-                .bind_value(self, 'bed_number').bind_visibility_from(beds_switch, 'value')
+                .bind_value(self, 'bed_count').bind_visibility_from(beds_switch, 'value')
             ui.number('Bed Spacing', suffix='cm',
                       value=50, step=1, min=1) \
                 .props('dense outlined').classes('w-40') \
@@ -126,8 +126,8 @@ class FieldCreator:
                 ui.label(f'Field Name: {self.field_name}').classes('text-lg')
                 ui.label(f'First Row Start: {self.first_row_start}').classes('text-lg')
                 ui.label(f'First Row End: {self.first_row_end}').classes('text-lg')
-                if self.bed_number > 1:
-                    ui.label(f'Number of Beds: {self.bed_number}').classes('text-lg')
+                if self.bed_count > 1:
+                    ui.label(f'Number of Beds: {self.bed_count}').classes('text-lg')
                     ui.label(f'Bed Spacing: {self.bed_spacing*100} cm').classes('text-lg')
                 ui.label(f'Row Spacing: {self.row_spacing*100} cm').classes('text-lg')
                 ui.label(f'Number of Rows (per Bed): {self.row_count}').classes('text-lg')
@@ -141,15 +141,15 @@ class FieldCreator:
         if self.first_row_start is None or self.first_row_end is None:
             ui.notify('No valid field parameters.')
             return
-        if self.bed_number > 1:
+        if self.bed_count > 1:
             self.field_provider.create_field(Field(id=str(uuid4()),
                                                    name=self.field_name,
                                                    first_row_start=self.first_row_start,
                                                    first_row_end=self.first_row_end,
                                                    row_spacing=self.row_spacing,
-                                                   row_count=self.row_count,
+                                                   row_count=int(self.row_count),
                                                    outline_buffer_width=self.outline_buffer_width,
-                                                   bed_count=self.bed_number,
+                                                   bed_count=int(self.bed_count),
                                                    bed_spacing=self.bed_spacing))
         else:
             self.field_provider.create_field(Field(id=str(uuid4()),
@@ -157,7 +157,7 @@ class FieldCreator:
                                                    first_row_start=self.first_row_start,
                                                    first_row_end=self.first_row_end,
                                                    row_spacing=self.row_spacing,
-                                                   row_count=self.row_count,
+                                                   row_count=int(self.row_count),
                                                    outline_buffer_width=self.outline_buffer_width))
         self.first_row_start = None
         self.first_row_end = None

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -84,10 +84,10 @@ class FieldCreator:
                 .tooltip('Set the distance between the beds') \
                 .bind_value(self, 'bed_spacing', forward=lambda v: v / 100.0, backward=lambda v: v * 100.0) \
                 .bind_visibility_from(beds_switch, 'value')
-            ui.number('Number of Rows',
+            ui.number('Number of Rows (per Bed)',
                       value=10, step=1, min=1) \
                 .props('dense outlined').classes('w-40') \
-                .tooltip('Set the number of rows.')\
+                .tooltip('Set the number of rows (per bed, if multiple beds are selected).')\
                 .bind_value(self, 'row_count')
             ui.number('Row Spacing', suffix='cm',
                       value=50, step=1, min=1) \
@@ -130,7 +130,7 @@ class FieldCreator:
                     ui.label(f'Number of Beds: {self.bed_number}').classes('text-lg')
                     ui.label(f'Bed Spacing: {self.bed_spacing*100} cm').classes('text-lg')
                 ui.label(f'Row Spacing: {self.row_spacing*100} cm').classes('text-lg')
-                ui.label(f'Number of Rows: {self.row_count}').classes('text-lg')
+                ui.label(f'Number of Rows (per Bed): {self.row_count}').classes('text-lg')
                 ui.label(f'Outline Buffer Width: {self.outline_buffer_width} m').classes('text-lg')
             with ui.row().classes('items-center'):
                 ui.button('Cancel', on_click=self.dialog.close).props('color=red')

--- a/field_friend/interface/components/leaflet_map.py
+++ b/field_friend/interface/components/leaflet_map.py
@@ -109,7 +109,7 @@ class leaflet_map:
         self.m.set_zoom(self.current_basemap.options['maxZoom'] - 1)
 
     def zoom_to_field(self) -> None:
-        field = self.field_provider.fields[0] if len(self.field_provider.fields) > 0 else None
+        field = self.field_provider.selected_field if self.field_provider.selected_field else None
         if field is None:
             return
         coords = field.outline_as_tuples

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -78,7 +78,7 @@ class operation:
             self.system.field_provider.update_field_parameters(
                 self.system.field_provider.selected_field.id,
                 parameters['name'],
-                int(parameters['row_number']),
+                int(parameters['row_count']),
                 float(parameters['row_spacing']),
                 float(parameters['outline_buffer_width']),
                 int(parameters['bed_count']),
@@ -103,7 +103,7 @@ class operation:
         with ui.dialog() as self.edit_field_dialog, ui.card():
             parameters: dict = {
                 'name': self.field_provider.selected_field.name if self.field_provider.selected_field else '',
-                'row_number': self.field_provider.selected_field.row_number if self.field_provider.selected_field else 0,
+                'row_count': self.field_provider.selected_field.row_count if self.field_provider.selected_field else 0,
                 'row_spacing': self.field_provider.selected_field.row_spacing if self.field_provider.selected_field else 0.0,
                 'outline_buffer_width': self.field_provider.selected_field.outline_buffer_width if self.field_provider.selected_field else 2.0,
                 'bed_count': self.field_provider.selected_field.bed_count if self.field_provider.selected_field else 1,
@@ -119,9 +119,9 @@ class operation:
                 .props('dense outlined').classes('w-full') \
                 .bind_value(parameters, 'bed_spacing', forward=lambda v: v / 100.0, backward=lambda v: v * 100.0) \
                 .bind_visibility_from(parameters, 'bed_count', backward=lambda v: v is not None and v > 1)
-            ui.input('Row Number (per Bed)', value=parameters['row_number']) \
+            ui.input('Row Number (per Bed)', value=parameters['row_count']) \
                 .props('dense outlined').classes('w-full') \
-                .bind_value(parameters, 'row_number') \
+                .bind_value(parameters, 'row_count') \
                 .tooltip('Set the number of rows per bed.')
             ui.number('Row Spacing', value=parameters['row_spacing'], suffix='cm', min=1, step=1) \
                 .props('dense outlined').classes('w-full') \

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -21,6 +21,7 @@ class operation:
         self.key_controls = KeyControls(self.system)
         self.field_provider.FIELDS_CHANGED.register_ui(self.field_setting.refresh)
         self.field_provider.FIELD_SELECTED.register_ui(self.field_setting.refresh)
+        self.selected_beds: set[int] = set()
 
         with ui.row().classes('w-full').style('min-height: 100%; width: 55%;'):
             with ui.row().classes('m-4').style('width: calc(100% - 2rem)'):
@@ -153,14 +154,22 @@ class operation:
                 on_change=lambda e: self.system.field_provider.select_field(e.value)
             ).classes('w-3/4')
             if self.system.field_provider.selected_field:
-                ui.button(icon='edit', on_click=self.edit_field_dialog.open) \
-                    .classes('ml-2') \
-                    .tooltip('Edit the selected field')
-                ui.button(icon='delete', on_click=self.delete_field_dialog.open) \
-                    .props('color=red') \
-                    .classes('ml-2') \
-                    .tooltip('Delete the selected field')
-        if self.system.field_provider.selected_field:
-            with ui.row().style('width:100%;'):
-                ui.button(icon='add_box', text='Row Point', on_click=lambda: SupportPointDialog(self.system)) \
-                    .tooltip('Add a support point for a row')
+                with ui.row():
+                    ui.button(icon='edit', on_click=self.edit_field_dialog.open) \
+                        .classes('ml-2') \
+                        .tooltip('Edit the selected field')
+                    ui.button(icon='add_box', text='Row Point', on_click=lambda: SupportPointDialog(self.system)) \
+                        .tooltip('Add a support point for a row')
+                    ui.button(icon='delete', on_click=self.delete_field_dialog.open) \
+                        .props('color=red') \
+                        .classes('ml-2') \
+                        .tooltip('Delete the selected field')
+                if self.system.field_provider.selected_field.bed_count > 1:
+                    with ui.row().classes('w-full'):
+                        beds_checkbox = ui.checkbox('Select specific beds').classes(
+                            'w-full').on_value_change(lambda: self.system.field_provider.clear_selected_beds())
+                        with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
+                            ui.select(list(range(1, int(self.system.field_provider.selected_field.bed_count) + 1)), multiple=True, label='selected beds') \
+                                .classes('w-full').props('use-chips').bind_value(self.system.field_provider, 'selected_beds')
+                        ui.button('Print Selected Beds', on_click=lambda: print(f"Selected beds: {self.system.field_provider.selected_beds}")) \
+                            .classes('w-full mt-2')

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -169,7 +169,5 @@ class operation:
                         beds_checkbox = ui.checkbox('Select specific beds').classes(
                             'w-full').on_value_change(lambda: self.system.field_provider.clear_selected_beds())
                         with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
-                            ui.select(list(range(1, int(self.system.field_provider.selected_field.bed_count) + 1)), multiple=True, label='selected beds') \
-                                .classes('w-full').props('use-chips').bind_value(self.system.field_provider, 'selected_beds')
-                        ui.button('Print Selected Beds', on_click=lambda: print(f"Selected beds: {self.system.field_provider.selected_beds}")) \
-                            .classes('w-full mt-2')
+                            ui.select(list(range(1, int(self.system.field_provider.selected_field.bed_count) + 1)), multiple=True, label='selected beds', clearable=True) \
+                                .classes('grow').props('use-chips').bind_value(self.system.field_provider, 'selected_beds')

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -167,7 +167,7 @@ class operation:
                 if self.system.field_provider.selected_field.bed_count > 1:
                     with ui.row().classes('w-full'):
                         beds_checkbox = ui.checkbox('Select specific beds').classes(
-                            'w-full').on_value_change(lambda: self.system.field_provider.clear_selected_beds())
+                            'w-full').on_value_change(self.system.field_provider.clear_selected_beds)
                         with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
                             ui.select(list(range(1, int(self.system.field_provider.selected_field.bed_count) + 1)), multiple=True, label='selected beds', clearable=True) \
                                 .classes('grow').props('use-chips').bind_value(self.system.field_provider, 'selected_beds')

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -80,7 +80,9 @@ class operation:
                 parameters['name'],
                 int(parameters['row_number']),
                 float(parameters['row_spacing']),
-                float(parameters['outline_buffer_width'])
+                float(parameters['outline_buffer_width']),
+                int(parameters['bed_count']),
+                float(parameters['bed_spacing'])
             )
             ui.notify(f'Parameters of Field "{name}" has been changed')
         else:
@@ -103,14 +105,24 @@ class operation:
                 'name': self.field_provider.selected_field.name if self.field_provider.selected_field else '',
                 'row_number': self.field_provider.selected_field.row_number if self.field_provider.selected_field else 0,
                 'row_spacing': self.field_provider.selected_field.row_spacing if self.field_provider.selected_field else 0.0,
-                'outline_buffer_width': self.field_provider.selected_field.outline_buffer_width if self.field_provider.selected_field else 2.0
+                'outline_buffer_width': self.field_provider.selected_field.outline_buffer_width if self.field_provider.selected_field else 2.0,
+                'bed_count': self.field_provider.selected_field.bed_count if self.field_provider.selected_field else 1,
+                'bed_spacing': self.field_provider.selected_field.bed_spacing if self.field_provider.selected_field else 0.5
             }
             ui.input('Field Name', value=parameters['name']) \
                 .props('dense outlined').classes('w-full') \
                 .bind_value(parameters, 'name')
-            ui.input('Row Number', value=parameters['row_number']) \
+            ui.number('Number of Beds', value=parameters['bed_count'], min=1, step=1) \
                 .props('dense outlined').classes('w-full') \
-                .bind_value(parameters, 'row_number')
+                .bind_value(parameters, 'bed_count')
+            ui.number('Bed Spacing', value=parameters['bed_spacing'], suffix='cm', min=1, step=1) \
+                .props('dense outlined').classes('w-full') \
+                .bind_value(parameters, 'bed_spacing', forward=lambda v: v / 100.0, backward=lambda v: v * 100.0) \
+                .bind_visibility_from(parameters, 'bed_count', backward=lambda v: v is not None and v > 1)
+            ui.input('Row Number (per Bed)', value=parameters['row_number']) \
+                .props('dense outlined').classes('w-full') \
+                .bind_value(parameters, 'row_number') \
+                .tooltip('Set the number of rows per bed.')
             ui.number('Row Spacing', value=parameters['row_spacing'], suffix='cm', min=1, step=1) \
                 .props('dense outlined').classes('w-full') \
                 .bind_value(parameters, 'row_spacing', forward=lambda v: v / 100.0, backward=lambda v: v * 100.0)

--- a/field_friend/interface/components/support_point_dialog.py
+++ b/field_friend/interface/components/support_point_dialog.py
@@ -49,7 +49,7 @@ class SupportPointDialog:
                 'text-lg')
             ui.label('2. Enter the row number for the support point:').classes('text-lg')
             ui.number(
-                label='Row Number', min=1, max=self.field_provider.fields[0].row_number if self.field_provider.fields else 1, step=1, value=1) \
+                label='Row Number', min=1, max=self.field_provider.fields[0].row_count if self.field_provider.fields else 1, step=1, value=1) \
                 .props('dense outlined').classes('w-40') \
                 .tooltip('Choose the row number you would like to give a fixed support point to.') \
                 .bind_value(self, 'row_name')

--- a/field_friend/interface/components/support_point_dialog.py
+++ b/field_friend/interface/components/support_point_dialog.py
@@ -22,6 +22,7 @@ class SupportPointDialog:
         self.gnss = system.gnss
         self.field_provider = system.field_provider
         self.row_name: int = 1
+        self.bed_number: int = 1
         self.support_point_coordinates: GeoPoint | None = None
         self.next: Callable = self.find_support_point
 
@@ -47,12 +48,25 @@ class SupportPointDialog:
             rosys.driving.joystick(self.steerer, size=50, color='#6E93D6')
             ui.label('1. Drive the robot on the row you want to give a fixed support point.').classes(
                 'text-lg')
-            ui.label('2. Enter the row number for the support point:').classes('text-lg')
-            ui.number(
-                label='Row Number', min=1, max=self.field_provider.fields[0].row_count if self.field_provider.fields else 1, step=1, value=1) \
-                .props('dense outlined').classes('w-40') \
-                .tooltip('Choose the row number you would like to give a fixed support point to.') \
-                .bind_value(self, 'row_name')
+            if self.field_provider.selected_field and self.field_provider.selected_field.bed_count == 1:
+                ui.label('2. Enter the row number for the support point:').classes('text-lg')
+                ui.number(
+                    label='Row Number', min=1, max=self.field_provider.selected_field.row_count, step=1, value=1) \
+                    .props('dense outlined').classes('w-40') \
+                    .tooltip('Choose the row number you would like to give a fixed support point to.') \
+                    .bind_value(self, 'row_name')
+            else:
+                ui.label('2. Enter the bed and row number for the support point:').classes('text-lg')
+                ui.number(
+                    label='Bed Number', min=1, max=self.field_provider.selected_field.bed_count, step=1, value=1) \
+                    .props('dense outlined').classes('w-40') \
+                    .tooltip('Choose the bed number the row is on.') \
+                    .bind_value(self, 'bed_number')
+                ui.number(
+                    label='Row Number', min=1, max=self.field_provider.selected_field.row_count, step=1, value=1) \
+                    .props('dense outlined').classes('w-40') \
+                    .tooltip('Choose the row number you would like to give a fixed support point to.') \
+                    .bind_value(self, 'row_name')
         self.next = self.confirm_support_point
 
     def confirm_support_point(self) -> None:
@@ -67,6 +81,7 @@ class SupportPointDialog:
             with ui.row().classes('items-center'):
                 ui.label(f'Support Point Coordinates: {self.support_point_coordinates}').classes('text-lg')
                 ui.label(f'Row Number: {round(self.row_name)}').classes('text-lg')
+                ui.label(f'Bed Number: {round(self.bed_number)}').classes('text-lg')
             with ui.row().classes('items-center'):
                 ui.button('Cancel', on_click=self.dialog.close).props('color=red')
         self.next = self._apply
@@ -76,8 +91,8 @@ class SupportPointDialog:
         if self.support_point_coordinates is None:
             ui.notify('No valid point coordinates.')
             return
-        row_index = self.row_name - 1
-        field = self.field_provider.fields[0]
+        field = self.field_provider.selected_field
+        row_index = (self.bed_number - 1) * field.row_count + self.row_name - 1
         row_support_point = RowSupportPoint.from_geopoint(self.support_point_coordinates, row_index)
         self.field_provider.add_row_support_point(field.id, row_support_point)
         ui.notify('Support point added.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,23 @@ async def field(system: System) -> AsyncGenerator[TestField, None]:
 
 
 @pytest.fixture
+async def field_with_beds(system: System) -> AsyncGenerator[TestField, None]:
+    test_field = TestField()
+    system.field_provider.create_field(Field(
+        id=test_field.id,
+        name="Test Field With Beds",
+        first_row_start=test_field.first_row_start,
+        first_row_end=test_field.first_row_end,
+        row_spacing=test_field.row_spacing,
+        row_count=1,
+        row_support_points=[],
+        bed_count=4,
+        bed_spacing=0.45
+    ))
+    yield test_field
+
+
+@pytest.fixture
 def field_creator(system: System) -> FieldCreator:
     fc = FieldCreator(system)
     fc.first_row_start = FIELD_FIRST_ROW_START

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ class TestField():
         self.first_row_start = FIELD_FIRST_ROW_START
         self.first_row_end = FIELD_FIRST_ROW_END
         self.row_spacing = 0.45
-        self.row_number = 4
+        self.row_count = 4
         self.outline_buffer_width = 2
         self.row_support_points = []
         self.rows = [
@@ -78,9 +78,9 @@ class TestField():
             self.first_row_start.shifted(Point(x=-self.outline_buffer_width, y=self.outline_buffer_width)),
             self.first_row_end.shifted(Point(x=self.outline_buffer_width, y=self.outline_buffer_width)),
             self.first_row_end.shifted(Point(x=self.outline_buffer_width, y=-
-                                       self.outline_buffer_width - (self.row_number - 1) * self.row_spacing)),
+                                       self.outline_buffer_width - (self.row_count - 1) * self.row_spacing)),
             self.first_row_start.shifted(Point(x=-self.outline_buffer_width, y=-
-                                         self.outline_buffer_width - (self.row_number - 1) * self.row_spacing)),
+                                         self.outline_buffer_width - (self.row_count - 1) * self.row_spacing)),
             self.first_row_start.shifted(Point(x=-self.outline_buffer_width, y=self.outline_buffer_width))
         ]
 
@@ -94,7 +94,7 @@ async def field(system: System) -> AsyncGenerator[TestField, None]:
         first_row_start=test_field.first_row_start,
         first_row_end=test_field.first_row_end,
         row_spacing=test_field.row_spacing,
-        row_number=test_field.row_number,
+        row_count=test_field.row_count,
         row_support_points=[]
     ))
     yield test_field
@@ -105,7 +105,7 @@ def field_creator(system: System) -> FieldCreator:
     fc = FieldCreator(system)
     fc.first_row_start = FIELD_FIRST_ROW_START
     fc.row_spacing = 0.5
-    fc.row_number = 10
+    fc.row_count = 10
     fc.confirm_geometry()
     fc.first_row_end = FIELD_FIRST_ROW_END
     return fc

--- a/tests/old_field_provider_persistence.json
+++ b/tests/old_field_provider_persistence.json
@@ -9,7 +9,7 @@
       },
       "first_row_end": { "lat": 51.98334192260392, "long": 7.434293309874038 },
       "row_spacing": 0.5,
-      "row_number": 10,
+      "row_count": 10,
       "outline_buffer_width": 2,
       "row_support_points": []
     }

--- a/tests/test_field_creator.py
+++ b/tests/test_field_creator.py
@@ -14,7 +14,7 @@ def test_field_creation(system: System, field_creator: FieldCreator):
     assert len(system.field_provider.fields) == 1
     assert system.field_provider.fields[0].name == 'Field'
     assert system.field_provider.fields[0].row_spacing == 0.5
-    assert system.field_provider.fields[0].row_number == 10
+    assert system.field_provider.fields[0].row_count == 10
     assert system.field_provider.fields[0].first_row_start == FIELD_FIRST_ROW_START
     assert system.field_provider.fields[0].first_row_end == FIELD_FIRST_ROW_END
     assert len(system.field_provider.fields[0].rows) == 10

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -14,7 +14,7 @@ def test_loading_from_old_persistence(system: System):
     system.field_provider.restore(json.loads(Path('tests/old_field_provider_persistence.json').read_text()))
     assert len(system.field_provider.fields) == 1
     field = system.field_provider.fields[0]
-    assert field.row_number == 10
+    assert field.row_count == 10
     assert field.row_spacing == 0.5
     assert field.outline_buffer_width == 2
     assert len(field.outline) == 5
@@ -37,7 +37,7 @@ def test_field_outline(system: System, field: Field):
         assert rounded_geo_point(point) in [rounded_geo_point(p) for p in outline]
 
     buffer = field.outline_buffer_width
-    row_offset = field.row_spacing * (field.row_number - 1)
+    row_offset = field.row_spacing * (field.row_count - 1)
 
     # Check first row boundary points
     assert_in_outline(field.first_row_start.shifted(Point(x=-buffer, y=buffer)))
@@ -154,7 +154,7 @@ def test_create_multiple_fields(system: System):
         name="Field 1",
         first_row_start=FIELD_FIRST_ROW_START,
         first_row_end=FIELD_FIRST_ROW_END,
-        row_number=5,
+        row_count=5,
         row_spacing=0.5
     )
     created_field1 = field_provider.create_field(field1)
@@ -167,7 +167,7 @@ def test_create_multiple_fields(system: System):
         name="Field 2",
         first_row_start=FIELD_FIRST_ROW_START.shifted(Point(x=10, y=10)),
         first_row_end=FIELD_FIRST_ROW_END.shifted(Point(x=10, y=10)),
-        row_number=3,
+        row_count=3,
         row_spacing=0.75
     )
     created_field2 = field_provider.create_field(field2)
@@ -175,11 +175,11 @@ def test_create_multiple_fields(system: System):
     assert field_provider.get_field(created_field2.id) == created_field2
 
     assert field_provider.fields[0].name == "Field 1"
-    assert field_provider.fields[0].row_number == 5
+    assert field_provider.fields[0].row_count == 5
     assert field_provider.fields[0].row_spacing == 0.5
 
     assert field_provider.fields[1].name == "Field 2"
-    assert field_provider.fields[1].row_number == 3
+    assert field_provider.fields[1].row_count == 3
     assert field_provider.fields[1].row_spacing == 0.75
 
     assert field_provider.fields[0].id != field_provider.fields[1].id

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -65,7 +65,7 @@ def test_add_row_support_point(system: System, field: Field):
     row_index = 2
     # check if distance between first and second row is correct before adding support point
     assert field.rows[0].points[0].distance(field.rows[row_index].points[0]) == pytest.approx(
-        row_index * field.row_spacing, abs=1e-6)
+        row_index * field.row_spacing, abs=1e-8)
     support_point = RowSupportPoint.from_geopoint(point, row_index)
     assert support_point.lat == point.lat
     assert support_point.long == point.long
@@ -78,7 +78,7 @@ def test_add_row_support_point(system: System, field: Field):
     assert updated_field.row_support_points[0].lat == pytest.approx(point.lat, abs=1e-9)
     assert updated_field.row_support_points[0].long == pytest.approx(point.long, abs=1e-9)
     # check if row was moved correctly
-    assert updated_field.rows[row_index].points[0].distance(point) == pytest.approx(0, abs=1e-6)
+    assert updated_field.rows[row_index].points[0].distance(point) == pytest.approx(0, abs=1e-8)
     assert updated_field.rows[row_index].points[0].lat == pytest.approx(point.lat, abs=1e-9)
     assert updated_field.rows[row_index].points[0].long == pytest.approx(point.long, abs=1e-9)
     # check if next row was moved correctly
@@ -107,17 +107,17 @@ def test_add_multiple_row_support_points(system: System, field: Field):
     assert [sp.long for sp in updated_field.row_support_points] == [
         second_row_shift_point.long, third_row_shift_point.long]
     # Check the distance between the first and second row
-    assert updated_field.rows[0].points[0].distance(updated_field.rows[1].points[0]) == pytest.approx(0.3, abs=1e-6)
-    assert updated_field.rows[0].points[1].distance(updated_field.rows[1].points[1]) == pytest.approx(0.3, abs=1e-6)
+    assert updated_field.rows[0].points[0].distance(updated_field.rows[1].points[0]) == pytest.approx(0.3, abs=1e-8)
+    assert updated_field.rows[0].points[1].distance(updated_field.rows[1].points[1]) == pytest.approx(0.3, abs=1e-8)
     # Check the distance between the first and third row
-    assert updated_field.rows[0].points[0].distance(updated_field.rows[2].points[0]) == pytest.approx(1.0, abs=1e-6)
-    assert updated_field.rows[0].points[1].distance(updated_field.rows[2].points[1]) == pytest.approx(1.0, abs=1e-6)
+    assert updated_field.rows[0].points[0].distance(updated_field.rows[2].points[0]) == pytest.approx(1.0, abs=1e-8)
+    assert updated_field.rows[0].points[1].distance(updated_field.rows[2].points[1]) == pytest.approx(1.0, abs=1e-8)
     # Check the distance between the first and fourth row
     expected_distance = 1.0 + field.row_spacing
     actual_distance_start_point = updated_field.rows[0].points[0].distance(updated_field.rows[3].points[0])
-    assert actual_distance_start_point == pytest.approx(expected_distance, abs=1e-6)
+    assert actual_distance_start_point == pytest.approx(expected_distance, abs=1e-8)
     actual_distance_end_point = updated_field.rows[0].points[1].distance(updated_field.rows[3].points[1])
-    assert actual_distance_end_point == pytest.approx(expected_distance, abs=1e-6)
+    assert actual_distance_end_point == pytest.approx(expected_distance, abs=1e-8)
 
 
 def test_update_existing_row_support_point(system: System, field: Field):
@@ -133,14 +133,14 @@ def test_update_existing_row_support_point(system: System, field: Field):
     assert updated_field is not None
     assert len(updated_field.row_support_points) == 1
     assert updated_field.row_support_points[0].row_index == 2  # 3rd row
-    assert updated_field.row_support_points[0].distance(updated_shift_point) == pytest.approx(0, abs=1e-6)
+    assert updated_field.row_support_points[0].distance(updated_shift_point) == pytest.approx(0, abs=1e-8)
     assert updated_field.rows[2].points[0].cartesian().distance(
-        updated_field.rows[0].points[0].cartesian()) == pytest.approx(2.0, abs=1e-6)
+        updated_field.rows[0].points[0].cartesian()) == pytest.approx(2.0, abs=1e-8)
     assert updated_field.rows[2].points[1].cartesian().distance(
-        updated_field.rows[0].points[1].cartesian()) == pytest.approx(2.0, abs=1e-6)
+        updated_field.rows[0].points[1].cartesian()) == pytest.approx(2.0, abs=1e-8)
     expected_distance = 2.45  # 3rd row support point + row spacing
     actual_distance = updated_field.rows[3].points[0].cartesian().distance(updated_field.rows[0].points[0].cartesian())
-    assert actual_distance == pytest.approx(expected_distance, abs=1e-6)
+    assert actual_distance == pytest.approx(expected_distance, abs=1e-8)
 
 
 def test_create_multiple_fields(system: System):
@@ -205,35 +205,46 @@ def test_delete_selected_field(system: System, field: Field):
     assert field_provider.get_field(field.id) is None
 
 
-def test_create_field_with_multiple_beds(system: System):
+def test_create_field_with_multiple_beds(system: System, field: Field):
     field_provider = system.field_provider
-    field = Field(
+    row_spacing = 0.5
+    bed_spacing = 1.5
+    row_count = 3
+    bed_count = 2
+
+    field_with_beds = Field(
         id=str(uuid.uuid4()),
         name="Multi-bed Field",
         first_row_start=FIELD_FIRST_ROW_START,
         first_row_end=FIELD_FIRST_ROW_END,
-        row_count=6,  # 2 beds with 3 rows each
-        row_spacing=0.5,
-        bed_count=2,
-        bed_spacing=1.5  # Wider spacing between beds
+        row_count=row_count,
+        row_spacing=row_spacing,
+        bed_count=bed_count,
+        bed_spacing=bed_spacing
     )
-    created_field = field_provider.create_field(field)
-    assert len(field_provider.fields) == 1
+    created_field = field_provider.create_field(field_with_beds)
+    assert len(field_provider.fields) == 2
     assert field_provider.get_field(created_field.id) == created_field
-
-    # Verify field properties
-    assert created_field.bed_count == 2
-    assert created_field.bed_spacing == 1.5
-    assert created_field.row_count == 6
-    assert created_field.row_spacing == 0.5
-
-    # Verify row positions
-    # First bed (3 rows)
-    assert created_field.rows[0].points[0] == field.first_row_start
-    assert created_field.rows[1].points[0] == field.first_row_start.shifted(Point(x=0, y=-0.5))
-    assert created_field.rows[2].points[0] == field.first_row_start.shifted(Point(x=0, y=-1.0))
-
-    # Second bed (3 rows) - starts after bed_spacing
-    assert created_field.rows[3].points[0] == field.first_row_start.shifted(Point(x=0, y=-2.5))  # -1.0 - 1.5
-    assert created_field.rows[4].points[0] == field.first_row_start.shifted(Point(x=0, y=-3.0))
-    assert created_field.rows[5].points[0] == field.first_row_start.shifted(Point(x=0, y=-3.5))
+    assert created_field.bed_count == bed_count
+    assert created_field.bed_spacing == bed_spacing
+    assert created_field.row_count == row_count
+    assert created_field.row_spacing == row_spacing
+    # Test first bed rows
+    for i in range(row_count):
+        expected_start = field_with_beds.first_row_start.shifted(Point(x=0, y=-i*row_spacing))
+        expected_end = field_with_beds.first_row_end.shifted(Point(x=0, y=-i*row_spacing))
+        assert created_field.rows[i].points[0].lat == pytest.approx(expected_start.lat, abs=1e-8)
+        assert created_field.rows[i].points[0].long == pytest.approx(expected_start.long, abs=1e-8)
+        assert created_field.rows[i].points[1].lat == pytest.approx(expected_end.lat, abs=1e-8)
+        assert created_field.rows[i].points[1].long == pytest.approx(expected_end.long, abs=1e-8)
+    assert created_field.rows[2].points[0].lat == pytest.approx(FIELD_FIRST_ROW_START.lat, abs=1e-8)
+    # Test second bed rows
+    for i in range(row_count):
+        row_index = i + row_count
+        y_offset = -((row_index-1)*row_spacing + bed_spacing)
+        expected_start = field_with_beds.first_row_start.shifted(Point(x=0, y=y_offset))
+        expected_end = field_with_beds.first_row_end.shifted(Point(x=0, y=y_offset))
+        assert created_field.rows[row_index].points[0].lat == pytest.approx(expected_start.lat, abs=1e-8)
+        assert created_field.rows[row_index].points[0].long == pytest.approx(expected_start.long, abs=1e-8)
+        assert created_field.rows[row_index].points[1].lat == pytest.approx(expected_end.lat, abs=1e-8)
+        assert created_field.rows[row_index].points[1].long == pytest.approx(expected_end.long, abs=1e-8)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -405,3 +405,35 @@ async def test_complete_field(system: System, field: Field):
     end_point = field.rows[-1].points[0].cartesian()
     assert system.odometer.prediction.point.x == pytest.approx(end_point.x, abs=0.05)
     assert system.odometer.prediction.point.y == pytest.approx(end_point.y, abs=0.05)
+
+
+async def test_complete_field_with_selected_beds(system: System, field_with_beds: Field):
+    # pylint: disable=protected-access
+    assert system.gnss.current
+    assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
+    system.field_provider.selected_beds = [1, 3]
+    system.field_provider.select_field(field_with_beds.id)
+    system.current_navigation = system.field_navigation
+    system.automator.start()
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FIELD_COMPLETED, timeout=1500)
+    assert system.automator.is_stopped
+    end_point = field_with_beds.rows[2].points[0].cartesian()
+    assert system.odometer.prediction.point.x == pytest.approx(end_point.x, abs=0.05)
+    assert system.odometer.prediction.point.y == pytest.approx(end_point.y, abs=0.05)
+
+
+async def test_complete_field_without_first_beds(system: System, field_with_beds: Field):
+    # pylint: disable=protected-access
+    assert system.gnss.current
+    assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
+    system.field_provider.selected_beds = [2, 3, 4]
+    system.field_provider.select_field(field_with_beds.id)
+    system.current_navigation = system.field_navigation
+    system.automator.start()
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FIELD_COMPLETED, timeout=1500)
+    assert system.automator.is_stopped
+    end_point = field_with_beds.rows[-1].points[1].cartesian()
+    assert system.odometer.prediction.point.x == pytest.approx(end_point.x, abs=0.05)
+    assert system.odometer.prediction.point.y == pytest.approx(end_point.y, abs=0.05)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -278,7 +278,7 @@ async def test_approaching_first_row(system: System, field: Field):
     await forward(until=lambda: system.current_implement.is_active)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.APPROACHING_ROW_START)
     for index, point in enumerate(field.rows[0].points):
-        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-6)
+        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-8)
     assert system.field_navigation.automation_watcher.field_watch_active
     assert system.automator.is_running
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FOLLOWING_ROW)
@@ -312,7 +312,7 @@ async def test_approaching_first_row_from_other_side(system: System, field: Fiel
     await forward(until=lambda: system.current_implement.is_active)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.APPROACHING_ROW_START)
     for index, point in enumerate(field.rows[0].points):
-        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-6)
+        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-8)
     assert system.field_navigation.automation_watcher.field_watch_active
     assert system.automator.is_running
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FOLLOWING_ROW)
@@ -342,7 +342,7 @@ async def test_approaching_first_row_when_outside_of_field(system: System, field
     await forward(until=lambda: system.field_navigation.automation_watcher.field_watch_active)
     await forward(until=lambda: system.current_implement.is_active)
     for index, point in enumerate(field.rows[0].points):
-        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-6)
+        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-8)
     await forward(until=lambda: system.automator.is_stopped)
     assert system.field_navigation._state == FieldNavigationState.APPROACHING_ROW_START
     assert system.odometer.prediction.point.x == pytest.approx(-10, abs=1.0)
@@ -361,7 +361,7 @@ async def test_complete_row(system: System, field: Field):
     await forward(until=lambda: system.field_navigation.automation_watcher.field_watch_active)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.APPROACHING_ROW_START)
     for index, point in enumerate(field.rows[0].points):
-        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-6)
+        assert system.field_navigation.current_row.points[index].distance(point) == pytest.approx(0, abs=1e-8)
     assert system.field_navigation.automation_watcher.field_watch_active
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FOLLOWING_ROW)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.APPROACHING_ROW_START)


### PR DESCRIPTION
After creating a simple field with row number, row spacing and buffer width this PR now adds the possibility to specify beds. By simple indicating the number of beds and the spacing between those, a field can how have beds. The row number will then be the number of rows per bed. Safety points still work as before and the calculation of the further rows are based on those.

Todo:

- [x] add beds in field creator
- [x] add beds in Field class (including persistence)
- [x] edit the row calculation
- [x] make beds editable
- [x] write tests
- [x] test on a robot