### PR TITLE
Continue on a row

### DIFF
--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -111,6 +111,11 @@ class FieldNavigation(StraightLineNavigation):
         elif relative_point_1 < relative_point_0:
             self.start_point = self.current_row.points[-1].cartesian()
             self.end_point = self.current_row.points[0].cartesian()
+
+        relative_start = self.odometer.prediction.relative_point(self.start_point).x
+        relative_end = self.odometer.prediction.relative_point(self.end_point).x
+        if relative_start < 0 <= relative_end:
+            self.start_point, self.end_point = self.end_point, self.start_point
         self.update_target()
         # self.log.info(f'Start point: {self.start_point} End point: {self.end_point}')
 


### PR DESCRIPTION
Currently, the robot wants to start at the nearest end of a row, but that leads to him turning on the row, if the start point is behind him.
This draft switches start and end point if the robot is between them.

I think this do more than that.
If the robot is directly on a row, it should skip the approach state and just continue weeding
If it's somewhere between two rows, it should not start and display a message for the user to return to a suitable starting position