### PR TITLE
Fix bed selection

### DIFF
--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -22,6 +22,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.FIELD_SELECTED = rosys.event.Event()
         """A field has been selected."""
 
+        self._only_specific_beds: bool = False
         self._selected_beds: list[int] = []
 
     @property
@@ -54,6 +55,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.FIELDS_CHANGED.emit()
         if self.selected_field and self.selected_field not in self.fields:
             self.selected_field = None
+            self._only_specific_beds = False
             self.selected_beds = []
             self.FIELD_SELECTED.emit()
 
@@ -135,6 +137,8 @@ class FieldProvider(rosys.persistence.PersistentModule):
             self.log.warning('No field selected. Cannot get rows to work on.')
             return []
         if self.selected_field.bed_count == 1:
+            return self.selected_field.rows
+        if not self._only_specific_beds:
             return self.selected_field.rows
         if len(self.selected_beds) == 0:
             self.log.warning('No beds selected. Cannot get rows to work on.')

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -16,11 +16,12 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.FIELDS_CHANGED = rosys.event.Event()
         """The dict of fields has changed."""
 
-        self.FIELDS_CHANGED.register(self.refresh_fields)
-
         self.selected_field: Field | None = None
         self.FIELD_SELECTED = rosys.event.Event()
         """A field has been selected."""
+
+        self.FIELDS_CHANGED.register(self.refresh_fields)
+        self.FIELD_SELECTED.register(self.clear_selected_beds)
 
         self._only_specific_beds: bool = False
         self._selected_beds: list[int] = []
@@ -130,6 +131,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.invalidate()
 
     def clear_selected_beds(self) -> None:
+        self._only_specific_beds = False
         self.selected_beds = []
 
     def get_rows_to_work_on(self) -> list[Row]:

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -172,8 +172,8 @@ class Operation:
                         .tooltip('Delete the selected field')
                 if self.system.field_provider.selected_field.bed_count > 1:
                     with ui.row().classes('w-full'):
-                        beds_checkbox = ui.checkbox('Select specific beds').classes(
-                            'w-full').bind_value(self.system.field_provider, '_only_specific_beds')
+                        beds_checkbox = ui.checkbox('Select specific beds').classes('w-full') \
+                            .bind_value(self.system.field_provider, '_only_specific_beds')
                         with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
                             ui.select(list(range(1, int(self.system.field_provider.selected_field.bed_count) + 1)), multiple=True, label='selected beds', clearable=True) \
                                 .classes('grow').props('use-chips').bind_value(self.system.field_provider, 'selected_beds')

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -173,7 +173,7 @@ class Operation:
                 if self.system.field_provider.selected_field.bed_count > 1:
                     with ui.row().classes('w-full'):
                         beds_checkbox = ui.checkbox('Select specific beds').classes(
-                            'w-full').on_value_change(self.system.field_provider.clear_selected_beds)
+                            'w-full').bind_value(self.system.field_provider, '_only_specific_beds')
                         with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
                             ui.select(list(range(1, int(self.system.field_provider.selected_field.bed_count) + 1)), multiple=True, label='selected beds', clearable=True) \
                                 .classes('grow').props('use-chips').bind_value(self.system.field_provider, 'selected_beds')

--- a/field_friend/interface/components/status_dev.py
+++ b/field_friend/interface/components/status_dev.py
@@ -182,7 +182,7 @@ def status_dev_page(robot: FieldFriend, system: System):
 
         with ui.row().classes('place-items-center'):
             ui.label('Odometry:').style('color: #EDF4FB').classes('font-bold')
-            ui.label().bind_text_from(system.odometer, 'prediction')
+            odometry_label = ui.label()
 
         with ui.row().classes('place-items-center'):
             ui.label('Since last update:').style('color: #EDF4FB').classes('font-bold')
@@ -265,6 +265,7 @@ def status_dev_page(robot: FieldFriend, system: System):
             localization.reference.lat == 0 and localization.reference.long == 0) else str(localization.reference)
         heading_label.text = f'{system.gnss.current.heading:.2f}° {direction_flag}' if system.gnss.current is not None and system.gnss.current.heading is not None else 'No heading'
         rtk_fix_label.text = f'gps_qual: {system.gnss.current.gps_qual}, mode: {system.gnss.current.mode}' if system.gnss.current is not None else 'No fix'
+        odometry_label.text = str(system.odometer.prediction)
         update_label.text = f'{timedelta(seconds=rosys.time() - system.gnss._last_gnss_pose.time)}'  # pylint: disable=protected-access
 
     ui.timer(rosys.config.ui_update_interval, update_status)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -10,9 +10,7 @@ from field_friend import System
 from field_friend.automations import Field
 from field_friend.automations.implements import Implement, Recorder
 from field_friend.automations.navigation import StraightLineNavigation
-from field_friend.automations.navigation.field_navigation import (
-    State as FieldNavigationState,
-)
+from field_friend.automations.navigation.field_navigation import State as FieldNavigationState
 from field_friend.localization import GnssSimulation
 
 
@@ -411,6 +409,7 @@ async def test_complete_field_with_selected_beds(system: System, field_with_beds
     # pylint: disable=protected-access
     assert system.gnss.current
     assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
+    system.field_provider._only_specific_beds = True
     system.field_provider.selected_beds = [1, 3]
     system.field_provider.select_field(field_with_beds.id)
     system.current_navigation = system.field_navigation
@@ -427,6 +426,7 @@ async def test_complete_field_without_first_beds(system: System, field_with_beds
     # pylint: disable=protected-access
     assert system.gnss.current
     assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
+    system.field_provider._only_specific_beds = True
     system.field_provider.selected_beds = [2, 3, 4]
     system.field_provider.select_field(field_with_beds.id)
     system.current_navigation = system.field_navigation

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -409,9 +409,9 @@ async def test_complete_field_with_selected_beds(system: System, field_with_beds
     # pylint: disable=protected-access
     assert system.gnss.current
     assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
+    system.field_provider.select_field(field_with_beds.id)
     system.field_provider._only_specific_beds = True
     system.field_provider.selected_beds = [1, 3]
-    system.field_provider.select_field(field_with_beds.id)
     system.current_navigation = system.field_navigation
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
@@ -426,9 +426,9 @@ async def test_complete_field_without_first_beds(system: System, field_with_beds
     # pylint: disable=protected-access
     assert system.gnss.current
     assert system.gnss.current.location.distance(ROBOT_GEO_START_POSITION) < 0.01
+    system.field_provider.select_field(field_with_beds.id)
     system.field_provider._only_specific_beds = True
     system.field_provider.selected_beds = [2, 3, 4]
-    system.field_provider.select_field(field_with_beds.id)
     system.current_navigation = system.field_navigation
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)


### PR DESCRIPTION
It wasn't possible to start an automation without selecting beds, now it just takes all rows as intended.
Additionally, the odometry info on the dev page is fixed