### PR TITLE
No Bumper Handling

### DIFF
--- a/field_friend/automations/automation_watcher.py
+++ b/field_friend/automations/automation_watcher.py
@@ -86,8 +86,9 @@ class AutomationWatcher:
 
     def try_resume(self) -> None:
         # Set conditions to True by default, which means they don't block the process if the watch is not active
-        # TODO: what to do if we don't have bumpers?
-        assert self.field_friend.bumper is not None
+        if self.field_friend.bumper is None:
+            self.log.warning('Bumper is not available, does robot has bumpers? ')
+            self.bumper_watch_active = False
         bumper_condition = not bool(self.field_friend.bumper.active_bumpers) if self.bumper_watch_active else True
         gnss_condition = (self.gnss.current is not None and ('R' in self.gnss.current.mode or self.gnss.current.mode == 'SSSS')) \
             if self.gnss_watch_active else True


### PR DESCRIPTION
When the robot has no bumper the automation_watch will throw an assertion as you can see in Issue #240. There are Fieldfriends that do not have bumpers at all. That is why we need an appropriate handling of it in the automation_watch. We would like to log a warning in case a robot with bumpers has an error or disconnected bumpers but beside that we just deactivate the bumper watcher.

 