### PR TITLE
change detector watchdog to debug log

### DIFF
--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -156,12 +156,12 @@ class PlantLocator(rosys.persistence.PersistentModule):
         if self.is_paused:
             return
         if rosys.time() - self.last_detection_time > 1.0 and not self.detector_error:
-            rosys.notify('No new detections', 'negative')
+            self.log.debug('No new detections')
             self.detector_error = True
             return
         if rosys.time() - self.last_detection_time <= 1.0 and self.detector_error:
             self.detector_error = False
-            rosys.notify('Detection error resolved', 'positive')
+            self.log.debug('Detection error resolved')
 
     async def get_outbox_mode(self, port: int) -> bool | None:
         # TODO: not needed right now, but can be used when this code is moved to the DetectorHardware code


### PR DESCRIPTION
When doing tests in the field, we noticed, that the watchdog is not relevant to the enduser. For this reason we are changing the notifications to a debug log.