### PR TITLE
Set default system variable values

### DIFF
--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -54,6 +54,7 @@ class Operation:
             ).classes('w-32') \
                 .tooltip('Select the navigation strategy') \
                 .bind_value_from(self.system, 'current_navigation', lambda i: i.name)
+            assert self.system.current_navigation is not None
             self.navigation_selection.value = self.system.current_navigation.name
 
             self.implement_selection = ui.select(
@@ -63,19 +64,24 @@ class Operation:
                 .classes('w-32') \
                 .tooltip('Select the implement to work with') \
                 .bind_value_from(self.system, 'current_implement', lambda i: i.name)
+            assert self.system.current_implement is not None
             self.implement_selection.value = self.system.current_implement.name
 
     def handle_implement_changed(self, e: events.ValueChangeEventArguments) -> None:
+        assert self.system.current_implement is not None
         if self.system.current_implement.name != e.value:
             self.system.current_implement = self.system.implements[e.value]
         self.implement_settings.clear()
+        assert self.system.current_implement is not None
         with self.implement_settings:
             self.system.current_implement.settings_ui()
 
     def handle_navigation_changed(self, e: events.ValueChangeEventArguments) -> None:
+        assert self.system.current_navigation is not None
         if self.system.current_navigation.name != e.value:
             self.system.current_navigation = self.system.navigation_strategies[e.value]
         self.navigation_settings.clear()
+        assert self.system.current_navigation is not None
         with self.navigation_settings:
             self.system.current_navigation.settings_ui()
 


### PR DESCRIPTION
When something fails during startup of `System`, other background tasks are already started and try to access variables of System, like here: `AttributeError: 'System' object has no attribute '_current_navigation'`
The problem is, these tasks will continue running and will fill up the log, which makes finding the error difficult.

The following log is just right after startup, while exception of the original error is just the first one, like here https://github.com/zauberzeug/field_friend/issues/264.

As a note:
We should rework how the current navigation and impement are served, but that is beyond the scope of this PR.

<details>
<summary>Error Message</summary>

```
rosys_1       | 2025-01-23 21:57:39.847 [INFO] rosys/hardware/gnss.py:206: Found GNSS device: /dev/ttyACM1
rosys_1       | 2025-01-23 21:57:39.848 [INFO] rosys/hardware/gnss.py:211: Connecting to GNSS device "/dev/ttyACM1"...
rosys_1       | 2025-01-23 21:57:39.848 [ERROR] nicegui/app/app.py:119: Could not connect to GNSS device: /dev/ttyACM1
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/serial/serialposix.py", line 322, in open
rosys_1       |     self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
rosys_1       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | OSError: [Errno 16] Device or resource busy: '/dev/ttyACM1'
rosys_1       | 
rosys_1       | During handling of the above exception, another exception occurred:
rosys_1       | 
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/hardware/gnss.py", line 213, in _connect_to_device
rosys_1       |     return serial.Serial(port=port, baudrate=baudrate, timeout=timeout)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/serial/serialutil.py", line 244, in __init__
rosys_1       |     self.open()
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/serial/serialposix.py", line 325, in open
rosys_1       |     raise SerialException(msg.errno, "could not open port {}: {}".format(self._port, msg))
rosys_1       | serial.serialutil.SerialException: [Errno 16] could not open port /dev/ttyACM1: [Errno 16] Device or resource busy: '/dev/ttyACM1'
rosys_1       | 
rosys_1       | The above exception was the direct cause of the following exception:
rosys_1       | 
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/app/nicegui/client.py", line 292, in safe_invoke
rosys_1       |     result = func(self) if len(inspect.signature(func).parameters) == 1 else func()
rosys_1       |                                                                              ^^^^^^
rosys_1       |   File "/app/main.py", line 28, in startup
rosys_1       |     system = System()
rosys_1       |              ^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 75, in __init__
rosys_1       |     self.gnss = self.setup_gnss()
rosys_1       |                 ^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 281, in setup_gnss
rosys_1       |     return GnssHardware(antenna_pose=antenna_pose)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/hardware/gnss.py", line 117, in __init__
rosys_1       |     self.serial_connection = self._connect_to_device(serial_device_path)
rosys_1       |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/hardware/gnss.py", line 215, in _connect_to_device
rosys_1       |     raise RuntimeError(f'Could not connect to GNSS device: {port}') from e
rosys_1       | RuntimeError: Could not connect to GNSS device: /dev/ttyACM1
rosys_1       | 2025-01-23 21:57:39.853 [ERROR] rosys/persistence/registry.py:65: failed to restore <field_friend.system.System object at 0xffff793e7790>
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 63, in restore
rosys_1       |     module.restore(json.loads(filepath.read_text()))
rosys_1       |   File "/app/field_friend/system.py", line 205, in restore
rosys_1       |     implement = self.implements.get(data.get('implement', None), None)
rosys_1       |                 ^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute 'implements'
rosys_1       | 2025-01-23 21:57:51.679 [ERROR] rosys/rosys.py:168: error in "backup"
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 47, in sync_backup
rosys_1       |     temp_filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
rosys_1       |                                         ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
rosys_1       | 
rosys_1       | During handling of the above exception, another exception occurred:
rosys_1       | 
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/rosys.py", line 162, in _repeat
rosys_1       |     await invoke(self.handler)
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/helpers/__init__.py", line 37, in invoke
rosys_1       |     result = await result
rosys_1       |              ^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 35, in backup
rosys_1       |     return await io_bound(sync_backup, force)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 30, in io_bound
rosys_1       |     return await run.io_bound(callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 45, in io_bound
rosys_1       |     return await _run(thread_pool, callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 23, in _run
rosys_1       |     return await loop.run_in_executor(executor, partial(callback, *args, **kwargs))
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
rosys_1       |     result = self.fn(*self.args, **self.kwargs)
rosys_1       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 50, in sync_backup
rosys_1       |     log.exception('failed to backup %s: %s', module, str(module.backup()))
rosys_1       |                                                          ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
rosys_1       | 2025-01-23 21:58:37.256 [ERROR] rosys/rosys.py:168: error in "backup"
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 47, in sync_backup
rosys_1       |     temp_filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
rosys_1       |                                         ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
rosys_1       | 
rosys_1       | During handling of the above exception, another exception occurred:
rosys_1       | 
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/rosys.py", line 162, in _repeat
rosys_1       |     await invoke(self.handler)
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/helpers/__init__.py", line 37, in invoke
rosys_1       |     result = await result
rosys_1       |              ^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 35, in backup
rosys_1       |     return await io_bound(sync_backup, force)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 30, in io_bound
rosys_1       |     return await run.io_bound(callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 45, in io_bound
rosys_1       |     return await _run(thread_pool, callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 23, in _run
rosys_1       |     return await loop.run_in_executor(executor, partial(callback, *args, **kwargs))
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
rosys_1       |     result = self.fn(*self.args, **self.kwargs)
rosys_1       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 50, in sync_backup
rosys_1       |     log.exception('failed to backup %s: %s', module, str(module.backup()))
rosys_1       |                                                          ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
rosys_1       | 2025-01-23 21:58:47.279 [ERROR] rosys/rosys.py:168: error in "backup"
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 47, in sync_backup
rosys_1       |     temp_filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
rosys_1       |                                         ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
rosys_1       | 
rosys_1       | During handling of the above exception, another exception occurred:
rosys_1       | 
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/rosys.py", line 162, in _repeat
rosys_1       |     await invoke(self.handler)
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/helpers/__init__.py", line 37, in invoke
rosys_1       |     result = await result
rosys_1       |              ^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 35, in backup
rosys_1       |     return await io_bound(sync_backup, force)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 30, in io_bound
rosys_1       |     return await run.io_bound(callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 45, in io_bound
rosys_1       |     return await _run(thread_pool, callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 23, in _run
rosys_1       |     return await loop.run_in_executor(executor, partial(callback, *args, **kwargs))
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
rosys_1       |     result = self.fn(*self.args, **self.kwargs)
rosys_1       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 50, in sync_backup
rosys_1       |     log.exception('failed to backup %s: %s', module, str(module.backup()))
rosys_1       |                                                          ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
rosys_1       | 2025-01-23 21:58:57.280 [ERROR] rosys/rosys.py:168: error in "backup"
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 47, in sync_backup
rosys_1       |     temp_filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
rosys_1       |                                         ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
rosys_1       | 
rosys_1       | During handling of the above exception, another exception occurred:
rosys_1       | 
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/rosys.py", line 162, in _repeat
rosys_1       |     await invoke(self.handler)
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/helpers/__init__.py", line 37, in invoke
rosys_1       |     result = await result
rosys_1       |              ^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 35, in backup
rosys_1       |     return await io_bound(sync_backup, force)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 30, in io_bound
rosys_1       |     return await run.io_bound(callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 45, in io_bound
rosys_1       |     return await _run(thread_pool, callback, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/nicegui/run.py", line 23, in _run
rosys_1       |     return await loop.run_in_executor(executor, partial(callback, *args, **kwargs))
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
rosys_1       |     result = self.fn(*self.args, **self.kwargs)
rosys_1       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 50, in sync_backup
rosys_1       |     log.exception('failed to backup %s: %s', module, str(module.backup()))
rosys_1       |                                                          ^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 199, in backup
rosys_1       |     'navigation': self.current_navigation.name,
rosys_1       |                   ^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/app/field_friend/system.py", line 233, in current_navigation
rosys_1       |     return self._current_navigation
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       | AttributeError: 'System' object has no attribute '_current_navigation'
```

</details>