### PR TITLE
Update to RoSys 0.22.1 to fix GNSS error #264

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-rosys == v0.22.0
+rosys == v0.22.1
 shapely
 uvicorn == 0.28.1


### PR DESCRIPTION
Fixes https://github.com/zauberzeug/field_friend/issues/264

- [x] Wait for RoSys 0.22.1 with https://github.com/zauberzeug/rosys/pull/254