### PR TITLE
Move GNSS distance to reference check to field navigation

### DIFF
--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -6,13 +6,12 @@ import numpy as np
 import rosys
 from nicegui import ui
 from rosys.analysis import track
-from rosys.geometry import GeoReference, Point
-from rosys.hardware import Gnss
+from rosys.geometry import Point
 
 from ..field import Field, Row
 from ..implements.implement import Implement
 from ..implements.weeding_implement import WeedingImplement
-from .navigation import WorkflowException
+from .navigation import WorkflowException, is_reference_valid
 from .straight_line_navigation import StraightLineNavigation
 
 if TYPE_CHECKING:
@@ -324,13 +323,3 @@ class FieldNavigation(StraightLineNavigation):
                         .polar(randint(-15, 15)*0.01, self.robot_locator.pose.yaw + np.pi/2)
                     self.detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
                                                                                         position=rosys.geometry.Point3d(x=p.x, y=p.y, z=0)))
-
-
-def is_reference_valid(gnss: Gnss, *, max_distance: float = 5000.0) -> bool:
-    if GeoReference.current is None:
-        return False
-    if gnss.last_measurement is None:
-        return False
-    if gnss.last_measurement.gps_quality == 0:
-        return False
-    return gnss.last_measurement.point.distance(GeoReference.current.origin) <= max_distance

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -8,23 +8,11 @@ import numpy as np
 import rosys
 from nicegui import ui
 from rosys.analysis import track
-from rosys.geometry import GeoReference
-from rosys.hardware import Gnss
 
 from ..implements.implement import Implement
 
 if TYPE_CHECKING:
     from ...system import System
-
-
-def is_reference_valid(gnss: Gnss, *, max_distance: float = 5000.0) -> bool:
-    if GeoReference.current is None:
-        return False
-    if gnss.last_measurement is None:
-        return False
-    if gnss.last_measurement.gps_quality == 0:
-        return False
-    return gnss.last_measurement.point.distance(GeoReference.current.origin) <= max_distance
 
 
 class WorkflowException(Exception):
@@ -61,8 +49,6 @@ class Navigation(rosys.persistence.PersistentModule):
             if not await self.prepare():
                 self.log.error('Preparation failed')
                 return
-            if not is_reference_valid(self.gnss):
-                raise WorkflowException('reference to far away from robot')
             self.start_position = self.robot_locator.pose.point
             if isinstance(self.driver.wheels, rosys.hardware.WheelsSimulation) and not rosys.is_test:
                 self.create_simulation()


### PR DESCRIPTION
We mostly use straight line indoors without a sufficient gnss signal, so the navigation fails.
This PR just warns the user when using a normal navigation without valid gnss. When running the field navigation it fails, because we definitely need it there.