### PR TITLE
Fixing missing bed_crops backup bug

### DIFF
--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -216,4 +216,5 @@ class Field:
             'row_support_points': [rosys.persistence.to_dict(sp) for sp in self.row_support_points],
             'bed_count': self.bed_count,
             'bed_spacing': self.bed_spacing,
+            'bed_crops': self.bed_crops
         }


### PR DESCRIPTION
I found a bug in backing up fields. At one point returning the bed_crops as part of the field is missing which leads to not making a backup with those bed_crops.