### PR TITLE
Remove unnecessary Pi in m_per_tick

### DIFF
--- a/field_friend/hardware/field_friend.py
+++ b/field_friend/hardware/field_friend.py
@@ -13,8 +13,8 @@ from .tornado import Tornado
 
 class FieldFriend(rosys.hardware.Robot):
     MOTOR_GEAR_RATIO = 12.52
-    WHEEL_DIAMETER = 0.041 * 17 / np.pi
-    M_PER_TICK = WHEEL_DIAMETER * np.pi / MOTOR_GEAR_RATIO
+    WHEEL_DIAMETER = 0.041 * 17
+    M_PER_TICK = WHEEL_DIAMETER / MOTOR_GEAR_RATIO
     WORK_X = 0.118
     WORK_Y = 0.0
     DRILL_RADIUS = 0.025

--- a/field_friend/hardware/field_friend_hardware.py
+++ b/field_friend/hardware/field_friend_hardware.py
@@ -1,4 +1,3 @@
-import numpy as np
 import rosys
 from rosys.hardware import ImuHardware
 
@@ -34,8 +33,8 @@ class FieldFriendHardware(FieldFriend, rosys.hardware.RobotHardware):
         self.MOTOR_GEAR_RATIO: float = config_params['motor_gear_ratio']
         self.THOOTH_COUNT: int = config_params['thooth_count']
         self.PITCH: float = config_params['pitch']
-        self.WHEEL_DIAMETER: float = self.THOOTH_COUNT * self.PITCH / np.pi
-        self.M_PER_TICK: float = self.WHEEL_DIAMETER * np.pi / self.MOTOR_GEAR_RATIO
+        self.WHEEL_DIAMETER: float = self.THOOTH_COUNT * self.PITCH
+        self.M_PER_TICK: float = self.WHEEL_DIAMETER / self.MOTOR_GEAR_RATIO
         self.WHEEL_DISTANCE: float = config_params['wheel_distance']
         self.ANTENNA_OFFSET: float = config_params['antenna_offset']
         self.WORK_X: float

--- a/field_friend/hardware/field_friend_simulation.py
+++ b/field_friend/hardware/field_friend_simulation.py
@@ -1,4 +1,3 @@
-import numpy as np
 import rosys
 from rosys.hardware import ImuSimulation
 
@@ -24,8 +23,8 @@ class FieldFriendSimulation(FieldFriend, rosys.hardware.RobotSimulation):
         self.MOTOR_GEAR_RATIO = config_params['motor_gear_ratio']
         self.THOOTH_COUNT = config_params['thooth_count']
         self.PITCH = config_params['pitch']
-        self.WHEEL_DIAMETER = self.THOOTH_COUNT * self.PITCH / np.pi
-        self.M_PER_TICK = self.WHEEL_DIAMETER * np.pi / self.MOTOR_GEAR_RATIO
+        self.WHEEL_DIAMETER = self.THOOTH_COUNT * self.PITCH
+        self.M_PER_TICK = self.WHEEL_DIAMETER / self.MOTOR_GEAR_RATIO
         self.WHEEL_DISTANCE = config_params['wheel_distance']
         tool = config_params['tool']
         if tool in ['tornado', 'weed_screw', 'none']:


### PR DESCRIPTION
When looking into the calculation for m_per_tick, we noticed, that the pi is canceld out. 
$` \frac{TC*P*\pi }{\pi*MGR}=\frac{TC*P}{MGR} `$
This will make the formula easier to understand and calculate. It also removes two imports.