### PR TITLE
Use tool offset in can_reach

### DIFF
--- a/field_friend/hardware/field_friend.py
+++ b/field_friend/hardware/field_friend.py
@@ -62,11 +62,14 @@ class FieldFriend(rosys.hardware.Robot):
         if self.z_axis:
             await self.z_axis.stop()
 
-    def can_reach(self, local_point: rosys.geometry.Point, second_tool: bool = False) -> bool:
+    def can_reach(self, local_point: rosys.geometry.Point, *, add_work_offset: bool = True, second_tool: bool = False) -> bool:
         """Check if the given point is reachable by the tool.
 
         The point is given in local coordinates, i.e. the origin is the center of the tool.
         """
+        if add_work_offset:
+            local_point.x += self.WORK_X
+            local_point.y += self.WORK_Y
         if self.implement_name in ['weed_screw', 'tornado'] and isinstance(self.y_axis, Axis):
             return self.y_axis.min_position <= local_point.y <= self.y_axis.max_position
         if self.implement_name in ['dual_mechanism'] and isinstance(self.y_axis, ChainAxis):

--- a/field_friend/interface/components/camera_card.py
+++ b/field_friend/interface/components/camera_card.py
@@ -212,44 +212,52 @@ class CameraCard:
 
     def to_svg(self, detections: rosys.vision.Detections) -> str:
         svg = ''
-        cross_size = 20
+        cross_size = 5
         for point in detections.points:
             if point.category_name in self.plant_locator.crop_category_names:
-                svg += f'<circle cx="{int(point.x / self.shrink_factor)}" cy="{int(point.y / self.shrink_factor)}" r="18" stroke-width="8" stroke="green" fill="none" />'
+                svg += f'<circle cx="{int(point.x / self.shrink_factor)}" cy="{int(point.y / self.shrink_factor)}" r="18" stroke-width="2" stroke="green" fill="none" />'
             elif point.category_name in self.plant_locator.weed_category_names:
-                svg += f'''<line x1="{int(point.x / self.shrink_factor) - cross_size}" y1="{int(point.y / self.shrink_factor)}" x2="{int(point.x / self.shrink_factor) + cross_size}" y2="{int(point.y / self.shrink_factor)}" stroke="red" stroke-width="8"
-    transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/><line x1="{int(point.x / self.shrink_factor)}" y1="{int(point.y / self.shrink_factor) - cross_size}" x2="{int(point.x / self.shrink_factor)}" y2="{int(point.y / self.shrink_factor) + cross_size}" stroke="red" stroke-width="8"
-    transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/>'''
+                svg += f'''<line x1="{int(point.x / self.shrink_factor) - cross_size}" y1="{int(point.y / self.shrink_factor)}" x2="{int(point.x / self.shrink_factor) + cross_size}" y2="{int(point.y / self.shrink_factor)}"
+                    stroke="red" stroke-width="2" transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/>
+                    <line x1="{int(point.x / self.shrink_factor)}" y1="{int(point.y / self.shrink_factor) - cross_size}" x2="{int(point.x / self.shrink_factor)}" y2="{int(point.y / self.shrink_factor) + cross_size}"
+                    stroke="red" stroke-width="2" transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/>'''
         return svg
 
     def build_svg_for_implement(self) -> str:
         if not isinstance(self.system.current_implement, WeedingImplement) or self.camera is None \
                 or self.camera.calibration is None or self.field_friend.y_axis is None:
             return ''
+
+        # TODO: change back when fixed
+        f15_work_x = 0.071
+        f15_work_y = -0.004
+
         svg = ''
-        tool_3d = rosys.geometry.Pose3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.position, z=0).in_frame(
-            self.robot_locator.pose_frame).resolve().point_3d
+        tool_3d = rosys.geometry.Pose3d(x=0, y=self.field_friend.y_axis.position, z=0) \
+            .in_frame(self.robot_locator.pose_frame).resolve().point_3d + rosys.geometry.Point3d(x=f15_work_x, y=f15_work_y, z=0)
         tool_2d = self.camera.calibration.project_to_image(tool_3d)
         if tool_2d:
             tool_2d = tool_2d / self.shrink_factor
-            svg = f'<circle cx="{int(tool_2d.x)}" cy="{int(tool_2d.y)}" r="10" fill="black"/>'
+            svg = f'<circle cx="{int(tool_2d.x)}" cy="{int(tool_2d.y)}" r="8" stroke="black" stroke-width="1" fill="none"/>'
 
-        min_tool_3d = rosys.geometry.Pose3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.min_position, z=0).in_frame(
-            self.robot_locator.pose_frame).resolve().point_3d
+        min_tool_3d = rosys.geometry.Pose3d(x=0, y=self.field_friend.y_axis.min_position, z=0) \
+            .in_frame(self.robot_locator.pose_frame).resolve().point_3d + rosys.geometry.Point3d(x=f15_work_x, y=f15_work_y, z=0)
         min_tool_2d = self.camera.calibration.project_to_image(min_tool_3d)
-        max_tool_3d = rosys.geometry.Pose3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.max_position, z=0).in_frame(
-            self.robot_locator.pose_frame).resolve().point_3d
+
+        max_tool_3d = rosys.geometry.Pose3d(x=0, y=self.field_friend.y_axis.max_position, z=0) \
+            .in_frame(self.robot_locator.pose_frame).resolve().point_3d + rosys.geometry.Point3d(x=f15_work_x, y=f15_work_y, z=0)
         max_tool_2d = self.camera.calibration.project_to_image(max_tool_3d)
+
         if min_tool_2d and max_tool_2d:
             min_tool_2d = min_tool_2d / self.shrink_factor
             max_tool_2d = max_tool_2d / self.shrink_factor
-            svg += f'<line x1="{int(min_tool_2d.x)}" y1="{int(min_tool_2d.y)}" x2="{int(max_tool_2d.x)}" y2="{int(max_tool_2d.y)}" stroke="black" stroke-width="2" />'
+            svg += f'<line x1="{int(min_tool_2d.x)}" y1="{int(min_tool_2d.y)}" x2="{int(max_tool_2d.x)}" y2="{int(max_tool_2d.y)}" stroke="black" stroke-width="1" />'
         if self.show_weeds_to_handle:
             for i, plant in enumerate(self.system.current_implement.weeds_to_handle.values()):
                 position_3d = self.robot_locator.pose.point_3d() + rosys.geometry.Point3d(x=plant.x, y=plant.y, z=0)
                 screen = self.camera.calibration.project_to_image(position_3d)
                 if screen is not None:
-                    svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="6" stroke="blue" fill="transparent" stroke-width="2" />'
+                    svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="6" stroke="blue" fill="transparent" stroke-width="1" />'
                     svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+4}" fill="blue" font-size="9" text-anchor="middle">{i}</text>'
         return svg
 
@@ -263,7 +271,7 @@ class CameraCard:
         for plant in self.plant_provider.get_relevant_weeds(position):
             screen = self.camera.calibration.project_to_image(plant.position)
             if screen is not None:
-                svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" fill="white" />'
+                svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" stroke="white" stroke-width="1" fill="none"/>'
                 svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+16}" fill="black" font-size="9" text-anchor="middle">{plant.id[:4]}</text>'
         return svg
 

--- a/field_friend/interface/components/camera_card.py
+++ b/field_friend/interface/components/camera_card.py
@@ -212,52 +212,44 @@ class CameraCard:
 
     def to_svg(self, detections: rosys.vision.Detections) -> str:
         svg = ''
-        cross_size = 5
+        cross_size = 20
         for point in detections.points:
             if point.category_name in self.plant_locator.crop_category_names:
-                svg += f'<circle cx="{int(point.x / self.shrink_factor)}" cy="{int(point.y / self.shrink_factor)}" r="18" stroke-width="2" stroke="green" fill="none" />'
+                svg += f'<circle cx="{int(point.x / self.shrink_factor)}" cy="{int(point.y / self.shrink_factor)}" r="18" stroke-width="8" stroke="green" fill="none" />'
             elif point.category_name in self.plant_locator.weed_category_names:
-                svg += f'''<line x1="{int(point.x / self.shrink_factor) - cross_size}" y1="{int(point.y / self.shrink_factor)}" x2="{int(point.x / self.shrink_factor) + cross_size}" y2="{int(point.y / self.shrink_factor)}"
-                    stroke="red" stroke-width="2" transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/>
-                    <line x1="{int(point.x / self.shrink_factor)}" y1="{int(point.y / self.shrink_factor) - cross_size}" x2="{int(point.x / self.shrink_factor)}" y2="{int(point.y / self.shrink_factor) + cross_size}"
-                    stroke="red" stroke-width="2" transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/>'''
+                svg += f'''<line x1="{int(point.x / self.shrink_factor) - cross_size}" y1="{int(point.y / self.shrink_factor)}" x2="{int(point.x / self.shrink_factor) + cross_size}" y2="{int(point.y / self.shrink_factor)}" stroke="red" stroke-width="8"
+    transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/><line x1="{int(point.x / self.shrink_factor)}" y1="{int(point.y / self.shrink_factor) - cross_size}" x2="{int(point.x / self.shrink_factor)}" y2="{int(point.y / self.shrink_factor) + cross_size}" stroke="red" stroke-width="8"
+    transform="rotate(45, {int(point.x / self.shrink_factor)}, {int(point.y / self.shrink_factor)})"/>'''
         return svg
 
     def build_svg_for_implement(self) -> str:
         if not isinstance(self.system.current_implement, WeedingImplement) or self.camera is None \
                 or self.camera.calibration is None or self.field_friend.y_axis is None:
             return ''
-
-        # TODO: change back when fixed
-        f15_work_x = 0.071
-        f15_work_y = -0.004
-
         svg = ''
-        tool_3d = rosys.geometry.Pose3d(x=0, y=self.field_friend.y_axis.position, z=0) \
-            .in_frame(self.robot_locator.pose_frame).resolve().point_3d + rosys.geometry.Point3d(x=f15_work_x, y=f15_work_y, z=0)
+        tool_3d = rosys.geometry.Pose3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.position, z=0).in_frame(
+            self.robot_locator.pose_frame).resolve().point_3d
         tool_2d = self.camera.calibration.project_to_image(tool_3d)
         if tool_2d:
             tool_2d = tool_2d / self.shrink_factor
-            svg = f'<circle cx="{int(tool_2d.x)}" cy="{int(tool_2d.y)}" r="8" stroke="black" stroke-width="1" fill="none"/>'
+            svg = f'<circle cx="{int(tool_2d.x)}" cy="{int(tool_2d.y)}" r="10" fill="black"/>'
 
-        min_tool_3d = rosys.geometry.Pose3d(x=0, y=self.field_friend.y_axis.min_position, z=0) \
-            .in_frame(self.robot_locator.pose_frame).resolve().point_3d + rosys.geometry.Point3d(x=f15_work_x, y=f15_work_y, z=0)
+        min_tool_3d = rosys.geometry.Pose3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.min_position, z=0).in_frame(
+            self.robot_locator.pose_frame).resolve().point_3d
         min_tool_2d = self.camera.calibration.project_to_image(min_tool_3d)
-
-        max_tool_3d = rosys.geometry.Pose3d(x=0, y=self.field_friend.y_axis.max_position, z=0) \
-            .in_frame(self.robot_locator.pose_frame).resolve().point_3d + rosys.geometry.Point3d(x=f15_work_x, y=f15_work_y, z=0)
+        max_tool_3d = rosys.geometry.Pose3d(x=self.field_friend.WORK_X, y=self.field_friend.y_axis.max_position, z=0).in_frame(
+            self.robot_locator.pose_frame).resolve().point_3d
         max_tool_2d = self.camera.calibration.project_to_image(max_tool_3d)
-
         if min_tool_2d and max_tool_2d:
             min_tool_2d = min_tool_2d / self.shrink_factor
             max_tool_2d = max_tool_2d / self.shrink_factor
-            svg += f'<line x1="{int(min_tool_2d.x)}" y1="{int(min_tool_2d.y)}" x2="{int(max_tool_2d.x)}" y2="{int(max_tool_2d.y)}" stroke="black" stroke-width="1" />'
+            svg += f'<line x1="{int(min_tool_2d.x)}" y1="{int(min_tool_2d.y)}" x2="{int(max_tool_2d.x)}" y2="{int(max_tool_2d.y)}" stroke="black" stroke-width="2" />'
         if self.show_weeds_to_handle:
             for i, plant in enumerate(self.system.current_implement.weeds_to_handle.values()):
                 position_3d = self.robot_locator.pose.point_3d() + rosys.geometry.Point3d(x=plant.x, y=plant.y, z=0)
                 screen = self.camera.calibration.project_to_image(position_3d)
                 if screen is not None:
-                    svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="6" stroke="blue" fill="transparent" stroke-width="1" />'
+                    svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="6" stroke="blue" fill="transparent" stroke-width="2" />'
                     svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+4}" fill="blue" font-size="9" text-anchor="middle">{i}</text>'
         return svg
 
@@ -271,7 +263,7 @@ class CameraCard:
         for plant in self.plant_provider.get_relevant_weeds(position):
             screen = self.camera.calibration.project_to_image(plant.position)
             if screen is not None:
-                svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" stroke="white" stroke-width="1" fill="none"/>'
+                svg += f'<circle cx="{int(screen.x/self.shrink_factor)}" cy="{int(screen.y/self.shrink_factor)}" r="5" fill="white" />'
                 svg += f'<text x="{int(screen.x/self.shrink_factor)}" y="{int(screen.y/self.shrink_factor)+16}" fill="black" font-size="9" text-anchor="middle">{plant.id[:4]}</text>'
         return svg
 


### PR DESCRIPTION
All tools are at least slightly off the center of the robot and that has to be taken in account when weeding.
Before, the work offsets were added in the puncher, but not in the `can_reach` function, which led to errors when the robot drove to a weed that it in the end couldn't reach.