### PR TITLE
Fetch detector info if not available

### DIFF
--- a/field_friend/automations/implements/recorder.py
+++ b/field_friend/automations/implements/recorder.py
@@ -18,8 +18,15 @@ class Recorder(Implement):
         super().__init__('Recorder')
         self.system = system
 
-    async def activate(self):
+    async def prepare(self) -> bool:
+        await super().prepare()
         self.system.plant_provider.clear()
+        if self.system.plant_locator.detector_info is None and not await self.system.plant_locator.fetch_detector_info():
+            rosys.notify('Dectection model information not available', 'negative')
+            return False
+        return True
+
+    async def activate(self):
         if self.system.field_friend.flashlight:
             await self.system.field_friend.flashlight.turn_on()
         await rosys.sleep(3)  # NOTE: we wait for the camera to adjust

--- a/field_friend/automations/implements/weeding_implement.py
+++ b/field_friend/automations/implements/weeding_implement.py
@@ -31,6 +31,7 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
         self.system = system
         self.puncher = system.puncher
         self.record_video = False
+        self.cultivated_crop_select: ui.select | None = None
         self.cultivated_crop: str | None = None
         self.crop_safety_distance: float = 0.01
 
@@ -49,6 +50,11 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
 
     async def prepare(self) -> bool:
         await super().prepare()
+        if self.system.plant_locator.detector_info is None and not await self.system.plant_locator.fetch_detector_info():
+            rosys.notify('Dectection model information not available', 'negative')
+            return False
+        assert self.cultivated_crop_select is not None
+        self.cultivated_crop_select.set_options(self.system.plant_locator.crop_category_names)
         self.log.info(f'start weeding {self.relevant_weeds} with {self.name} ...')
         self.request_backup()
         if not await self._check_hardware_ready():
@@ -181,7 +187,7 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
 
     def settings_ui(self) -> None:
         super().settings_ui()
-        ui.select(self.system.plant_locator.crop_category_names, label='cultivated crop', on_change=self.request_backup) \
+        self.cultivated_crop_select = ui.select(self.system.plant_locator.crop_category_names, label='cultivated crop', on_change=self.request_backup) \
             .bind_value(self, 'cultivated_crop').props('clearable') \
             .classes('w-40').tooltip('Set the cultivated crop which should be kept safe')
         ui.number('Crop safety distance', step=0.001, min=0.001, max=0.05, format='%.3f', on_change=self.request_backup) \

--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -6,13 +6,15 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 import rosys
 from nicegui import ui
-from rosys.vision import Autoupload
+from rosys.vision import Autoupload, DetectorSimulation
+from rosys.vision.detections import Category
+from rosys.vision.detector import DetectorException, DetectorInfo
 
 from ..vision.zedxmini_camera import StereoCamera
 from .entity_locator import EntityLocator
 from .plant import Plant
 
-WEED_CATEGORY_NAME = ['coin', 'weed', 'weedy_area', ]
+WEED_CATEGORY_NAME = ['weed', 'weedy_area', 'coin', 'danger', 'big_weed']
 CROP_CATEGORY_NAME: dict[str, str] = {}
 MINIMUM_CROP_CONFIDENCE = 0.3
 MINIMUM_WEED_CONFIDENCE = 0.3
@@ -35,6 +37,7 @@ class PlantLocator(EntityLocator):
         self.plant_provider = system.plant_provider
         self.robot_locator = system.robot_locator
         self.robot_name = system.version
+        self.detector_info: rosys.vision.DetectorInfo | None = None
         self.tags: list[str] = []
         self.is_paused = True
         self.autoupload: Autoupload = Autoupload.DISABLED
@@ -55,7 +58,7 @@ class PlantLocator(EntityLocator):
         self.last_detection_time = rosys.time()
         self.detector.NEW_DETECTIONS.register(lambda e: setattr(self, 'last_detection_time', rosys.time()))
         rosys.on_repeat(self._detection_watchdog, 0.5)
-        rosys.on_startup(self.get_crop_names)
+        rosys.on_startup(self.fetch_detector_info)
 
     def backup(self) -> dict:
         self.log.debug(f'backup: autoupload: {self.autoupload}')
@@ -187,6 +190,8 @@ class PlantLocator(EntityLocator):
                     .classes('w-28') \
                     .bind_value(self, 'autoupload') \
                     .tooltip('Set the autoupload for the weeding automation')
+            ui.label().bind_text_from(self, 'detector_info',
+                                      backward=lambda info: f'Detector version: {info.current_version}/{info.target_version}' if info else 'Detector version: unknown')
 
             @ui.refreshable
             def chips():
@@ -224,25 +229,21 @@ class PlantLocator(EntityLocator):
         else:
             self.upload_images = False
 
-    async def get_crop_names(self) -> dict[str, str]:
-        if isinstance(self.detector, rosys.vision.DetectorSimulation):
-            simulated_crop_names: list[str] = ['coin_with_hole', 'borrietsch', 'estragon', 'feldsalat', 'garlic', 'jasione', 'kohlrabi', 'liebstoeckel', 'maize', 'minze', 'onion',
-                                               'oregano_majoran', 'pastinake', 'petersilie', 'pimpinelle', 'red_beet', 'salatkopf', 'schnittlauch', 'sugar_beet', 'thymian_bohnenkraut', 'zitronenmelisse', ]
-
-            CROP_CATEGORY_NAME.update({name: name.replace('_', ' ').title() for name in simulated_crop_names})
-            self.crop_category_names = CROP_CATEGORY_NAME
-            return CROP_CATEGORY_NAME
-        port = self.detector.port
-        url = f'http://localhost:{port}/about'
-        async with aiohttp.request('GET', url) as response:
-            if response.status != 200:
-                self.log.error(f'Could not get crop names on port {port} - status code: {response.status}')
-                return {}
-            response_text = await response.json()
-        crop_names: list[str] = [category['name'] for category in response_text['model_info']['categories']]
-        weeds = ['weed', 'weedy_area', 'coin', 'danger', 'big_weed']
-        for weed in weeds:
-            crop_names.remove(weed)
-        CROP_CATEGORY_NAME.update({name: name.replace('_', ' ').title() for name in crop_names})
+    async def fetch_detector_info(self) -> bool:
+        try:
+            detector_info: DetectorInfo = await self.detector.fetch_detector_info()
+        except DetectorException as e:
+            self.log.error(f'Could not fetch detector info: {e}')
+            return False
+        if isinstance(self.detector, DetectorSimulation):
+            detector_info.categories = [Category(uuid=name, name=name) for name in ['coin_with_hole', 'borrietsch', 'estragon', 'feldsalat', 'garlic', 'jasione', 'kohlrabi', 'liebstoeckel', 'maize', 'minze', 'onion',
+                                        'oregano_majoran', 'pastinake', 'petersilie', 'pimpinelle', 'red_beet', 'salatkopf', 'schnittlauch', 'sugar_beet', 'thymian_bohnenkraut', 'zitronenmelisse', ]]
+            detector_info.current_version = 'simulation'
+            detector_info.target_version = 'simulation'
+        filtered_crops: list[str] = [
+            category.name for category in detector_info.categories if category.name not in WEED_CATEGORY_NAME]
+        CROP_CATEGORY_NAME.update({crop_name: crop_name.replace('_', ' ').title() for crop_name in filtered_crops})
+        self.detector_info = detector_info
         self.crop_category_names = CROP_CATEGORY_NAME
-        return CROP_CATEGORY_NAME
+        self.log.debug('Fetched detector info: %s', detector_info)
+        return True


### PR DESCRIPTION
As described in https://github.com/zauberzeug/field_friend/issues/284, the crop categories are only fetched once on startup. If the detector is not available in this moment, the categories will be empty and no crops can be detected.

This PR fetches them on startup and at the start of an automation. Additionaly I replaced the self built request by [detector.fetch_model_version_info](https://github.com/zauberzeug/rosys/blob/2c08346da93eccf908657358be274268a4c512a1/rosys/vision/detector.py#L144) and the current and target model versions are displayed in the dev ui.