### PR TITLE
Avoid UART wheel speed spam

### DIFF
--- a/field_friend/hardware/double_wheels.py
+++ b/field_friend/hardware/double_wheels.py
@@ -1,5 +1,3 @@
-
-
 import rosys
 from rosys.helpers import remove_indentation
 
@@ -55,7 +53,10 @@ class DoubleWheelsHardware(rosys.hardware.Wheels, rosys.hardware.ModuleHardware)
                                        'l1.motor_error_flag', 'r1.motor_error_flag'])
         super().__init__(robot_brain=robot_brain, lizard_code=lizard_code, core_message_fields=core_message_fields)
 
-    async def drive(self, linear: float, angular: float) -> None:
+    async def drive(self, linear: float, angular: float, epsilon: float = 1e-6) -> None:
+        if (abs(linear - self.linear_target_speed) < epsilon and
+                abs(angular - self.angular_target_speed) < epsilon):
+            return
         await super().drive(linear, angular)
         if linear == 0.0:
             linear = -0.0

--- a/field_friend/hardware/double_wheels.py
+++ b/field_friend/hardware/double_wheels.py
@@ -53,7 +53,7 @@ class DoubleWheelsHardware(rosys.hardware.Wheels, rosys.hardware.ModuleHardware)
                                        'l1.motor_error_flag', 'r1.motor_error_flag'])
         super().__init__(robot_brain=robot_brain, lizard_code=lizard_code, core_message_fields=core_message_fields)
 
-    async def drive(self, linear: float, angular: float, epsilon: float = 1e-6) -> None:
+    async def drive(self, linear: float, angular: float, *, epsilon: float = 1e-6) -> None:
         if (abs(linear - self.linear_target_speed) < epsilon and
                 abs(angular - self.angular_target_speed) < epsilon):
             return


### PR DESCRIPTION
Before there was quite a lot of spam on the UART communication when driving forward, which is caused by this loop:
https://github.com/zauberzeug/field_friend/blob/c2f87f4a22e4fb9d0faf9853fa170823832a231c/field_friend/automations/navigation/navigation.py#L111-L117

```C
send: wheels.speed(0.2, 0.024891419245414687)@77
send: wheels.speed(-0.0, -0.0)@44
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
send: wheels.speed(0.2, 0.024256255720169286)@74
```

I think the set epsilon is more than ok. It equals to 1 µm/s and about 0.0000573 °/s.