### PR TITLE
Lower odrive max current

### DIFF
--- a/odrive/calibrate_two_motors_l.py
+++ b/odrive/calibrate_two_motors_l.py
@@ -43,7 +43,7 @@ for i, axis in enumerate([odrv0.axis0, odrv0.axis1]):
     print('- Motor configuration')
     assert_equal(axis.motor.config.pole_pairs, 8)
     assert_equal(axis.motor.config.calibration_current, 15)
-    assert_equal(axis.motor.config.current_lim, 35)
+    assert_equal(axis.motor.config.current_lim, 20)
     assert_equal(axis.motor.config.current_lim_margin, 15)
     assert_equal(axis.motor.config.torque_constant, 1.4500000476837158)
     assert_equal(axis.motor.config.torque_lim, 100)

--- a/odrive/calibrate_two_motors_r.py
+++ b/odrive/calibrate_two_motors_r.py
@@ -43,7 +43,7 @@ for i, axis in enumerate([odrv0.axis0, odrv0.axis1]):
     print('- Motor configuration')
     assert_equal(axis.motor.config.pole_pairs, 8)
     assert_equal(axis.motor.config.calibration_current, 15)
-    assert_equal(axis.motor.config.current_lim, 35)
+    assert_equal(axis.motor.config.current_lim, 20)
     assert_equal(axis.motor.config.current_lim_margin, 15)
     assert_equal(axis.motor.config.torque_constant, 1.4500000476837158)
     assert_equal(axis.motor.config.torque_lim, 100)


### PR DESCRIPTION
This will limit the maximum continous draw of the odrives to 20 A 