### PR TITLE
Start bed and row indices at 0

### DIFF
--- a/field_friend/api/fields.py
+++ b/field_friend/api/fields.py
@@ -75,8 +75,8 @@ class Fields:
                 if is_inside:
                     row = min(field.rows, key=lambda r: r.line_segment().line.foot_point(
                         self.system.robot_locator.pose.point).distance(self.system.robot_locator.pose.point))  # nearest row
-                    row_index = int(row.id.split('_')[-1]) - 1  # -1 because row IDs start at 1
-                    bed_id = int(row_index // field.row_count) + 1  # +1 because bed IDs start at 1
+                    row_index = int(row.id.split('_')[-1])
+                    bed_id = int(row_index // field.row_count)
                 return JSONResponse(
                     content={'status': 'ok', 'inside': is_inside, 'beds': [bed_id]},
                     status_code=200

--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -128,18 +128,18 @@ class Field:
                 offset = last_support_point_offset
                 if beds_crossed > 0:
                     offset += beds_crossed * self.bed_spacing
-                    rows_in_complete_beds = rows_since_support - (row_in_bed + 1)
+                    rows_in_complete_beds = rows_since_support - (row_in_bed)
                     offset += rows_in_complete_beds * self.row_spacing
                     offset += row_in_bed * self.row_spacing
                 else:
                     offset += rows_since_support * self.row_spacing
             else:
                 base_offset = row_in_bed * self.row_spacing
-                bed_offset = bed_index * ((self.row_count - 1) * self.row_spacing + self.bed_spacing)
+                bed_offset = bed_index * ((self.row_count) * self.row_spacing + self.bed_spacing)
                 offset = base_offset + bed_offset
             offset_row_coordinated = offset_curve(ab_line_cartesian, -offset).coords
             row_points = [GeoPoint.from_point(Point(x=p[0], y=p[1])) for p in offset_row_coordinated]
-            row = Row(id=f'field_{self.id}_row_{i + 1!s}', name=f'row_{i + 1}',
+            row = Row(id=f'field_{self.id}_row_{i!s}', name=f'row_{i}',
                       points=row_points, crop=self.bed_crops[str(bed_index)])
             rows.append(row)
         return rows

--- a/field_friend/automations/field.py
+++ b/field_friend/automations/field.py
@@ -128,18 +128,18 @@ class Field:
                 offset = last_support_point_offset
                 if beds_crossed > 0:
                     offset += beds_crossed * self.bed_spacing
-                    rows_in_complete_beds = rows_since_support - (row_in_bed)
+                    rows_in_complete_beds = rows_since_support - (row_in_bed + 1)
                     offset += rows_in_complete_beds * self.row_spacing
                     offset += row_in_bed * self.row_spacing
                 else:
                     offset += rows_since_support * self.row_spacing
             else:
                 base_offset = row_in_bed * self.row_spacing
-                bed_offset = bed_index * ((self.row_count) * self.row_spacing + self.bed_spacing)
+                bed_offset = bed_index * ((self.row_count - 1) * self.row_spacing + self.bed_spacing)
                 offset = base_offset + bed_offset
             offset_row_coordinated = offset_curve(ab_line_cartesian, -offset).coords
             row_points = [GeoPoint.from_point(Point(x=p[0], y=p[1])) for p in offset_row_coordinated]
-            row = Row(id=f'field_{self.id}_row_{i!s}', name=f'row_{i}',
+            row = Row(id=f'field_{self.id}_row_{i}', name=f'row_{i}',
                       points=row_points, crop=self.bed_crops[str(bed_index)])
             rows.append(row)
         return rows

--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -160,7 +160,7 @@ class FieldProvider(rosys.persistence.PersistentModule):
         row_indices = []
         for bed in self.selected_beds:
             for row_index in range(self.selected_field.row_count):
-                row_indices.append((bed - 1) * self.selected_field.row_count + row_index)
+                row_indices.append(bed * self.selected_field.row_count + row_index)
         rows_to_work_on = [row for i, row in enumerate(self.selected_field.rows) if i in row_indices]
         return rows_to_work_on
 
@@ -169,5 +169,5 @@ class FieldProvider(rosys.persistence.PersistentModule):
             return True
         if self.selected_field is None:
             return False
-        bed_index = row_index // self.selected_field.row_count + 1
+        bed_index = row_index // self.selected_field.row_count
         return bed_index in self.selected_beds

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -152,10 +152,10 @@ class FieldCreator:
         with self.content:
             for i in range(int(self.bed_count)):
                 with ui.row().classes('w-full'):
-                    ui.label(f'Bed {i + 1}:').classes('text-lg')
+                    ui.label(f'Bed {i}:').classes('text-lg')
                     ui.select(options=self.plant_locator.crop_category_names) \
                         .props('dense outlined').classes('w-40') \
-                        .tooltip(f'Enter the crop name for bed {i + 1}') \
+                        .tooltip(f'Enter the crop name for bed {i}') \
                         .bind_value(self, 'bed_crops',
                                     forward=lambda v, idx=i: {**self.bed_crops,
                                                               str(idx): v if v is not None else self.default_crop},
@@ -177,7 +177,7 @@ class FieldCreator:
                     for i in range(int(self.bed_count)):
                         crop = self.bed_crops[str(i)]
                         crop_name = self.plant_locator.crop_category_names[crop] if crop is not None else 'No crop selected'
-                        ui.label(f'Bed {int(i) + 1}: {crop_name}').classes('text-lg')
+                        ui.label(f'Bed {int(i)}: {crop_name}').classes('text-lg')
                 ui.separator()
                 ui.label(f'Row Spacing: {self.row_spacing*100} cm').classes('text-lg')
                 ui.label(f'Number of Rows (per Bed): {self.row_count}').classes('text-lg')

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -200,7 +200,7 @@ class Operation:
                         beds_checkbox = ui.checkbox('Select specific beds').classes('w-full') \
                             .bind_value(self.system.field_provider, 'only_specific_beds')
                         with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
-                            ui.select(list(range(0, int(self.field_provider.selected_field.bed_count))),
+                            ui.select(list(range(0, int(self.field_provider.selected_field.bed_count) - 1)),
                                       multiple=True, label='selected beds', clearable=True) \
                                 .classes('grow').props('use-chips') \
                                 .bind_value(self.field_provider, 'selected_beds')

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -202,7 +202,7 @@ class Operation:
                         beds_checkbox = ui.checkbox('Select specific beds').classes('w-full') \
                             .bind_value(self.system.field_provider, 'only_specific_beds')
                         with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
-                            ui.select(list(range(0, int(self.field_provider.selected_field.bed_count) - 1)),
+                            ui.select(list(range(0, int(self.field_provider.selected_field.bed_count))),
                                       multiple=True, label='selected beds', clearable=True) \
                                 .classes('grow').props('use-chips') \
                                 .bind_value(self.field_provider, 'selected_beds')

--- a/field_friend/interface/components/operation.py
+++ b/field_friend/interface/components/operation.py
@@ -159,7 +159,7 @@ class Operation:
                     with ui.column().classes('w-full').style('max-height: 500px; overflow-y: auto;'):
                         for i in range(parameters['bed_count']):
                             with ui.row().classes('w-full item-center'):
-                                ui.label(f'Bed {i + 1}:').classes('text-lg')
+                                ui.label(f'Bed {i}:').classes('text-lg')
                                 ui.select(self.plant_locator.crop_category_names) \
                                     .props('dense outlined').classes('w-40') \
                                     .bind_value(parameters, 'bed_crops',
@@ -200,7 +200,7 @@ class Operation:
                         beds_checkbox = ui.checkbox('Select specific beds').classes('w-full') \
                             .bind_value(self.system.field_provider, 'only_specific_beds')
                         with ui.row().bind_visibility_from(beds_checkbox, 'value').classes('w-full'):
-                            ui.select(list(range(1, int(self.field_provider.selected_field.bed_count) + 1)),
+                            ui.select(list(range(0, int(self.field_provider.selected_field.bed_count))),
                                       multiple=True, label='selected beds', clearable=True) \
                                 .classes('grow').props('use-chips') \
                                 .bind_value(self.field_provider, 'selected_beds')

--- a/field_friend/interface/components/support_point_dialog.py
+++ b/field_friend/interface/components/support_point_dialog.py
@@ -99,7 +99,7 @@ class SupportPointDialog:
         if field is None:
             ui.notify('No field selected.')
             return
-        row_index = (self.bed_number) * field.row_count + self.row_name
+        row_index = self.bed_number * field.row_count + self.row_name
         row_support_point = RowSupportPoint.from_geopoint(self.support_point_coordinates, row_index)
         self.field_provider.add_row_support_point(field.id, row_support_point)
         ui.notify('Support point added.')

--- a/field_friend/interface/components/support_point_dialog.py
+++ b/field_friend/interface/components/support_point_dialog.py
@@ -25,8 +25,8 @@ class SupportPointDialog:
         self.steerer = system.steerer
         self.gnss = system.gnss
         self.field_provider = system.field_provider
-        self.row_name: int = 1
-        self.bed_number: int = 1
+        self.row_name: int = 0
+        self.bed_number: int = 0
         self.support_point_coordinates: GeoPoint | None = None
         self.next: Callable = self.find_support_point
 
@@ -55,19 +55,19 @@ class SupportPointDialog:
             if self.field_provider.selected_field and self.field_provider.selected_field.bed_count == 1:
                 ui.label('2. Enter the row number for the support point:').classes('text-lg')
                 ui.number(
-                    label='Row Number', min=1, max=self.field_provider.selected_field.row_count, step=1, value=1) \
+                    label='Row Number', min=0, max=self.field_provider.selected_field.row_count - 1, step=1, value=1) \
                     .props('dense outlined').classes('w-40') \
                     .tooltip('Choose the row number you would like to give a fixed support point to.') \
                     .bind_value(self, 'row_name')
             elif self.field_provider.selected_field is not None:
                 ui.label('2. Enter the bed and row number for the support point:').classes('text-lg')
                 ui.number(
-                    label='Bed Number', min=1, max=self.field_provider.selected_field.bed_count, step=1, value=1) \
+                    label='Bed Number', min=0, max=self.field_provider.selected_field.bed_count - 1, step=1, value=1) \
                     .props('dense outlined').classes('w-40') \
                     .tooltip('Choose the bed number the row is on.') \
                     .bind_value(self, 'bed_number')
                 ui.number(
-                    label='Row Number', min=1, max=self.field_provider.selected_field.row_count, step=1, value=1) \
+                    label='Row Number', min=0, max=self.field_provider.selected_field.row_count - 1, step=1, value=1) \
                     .props('dense outlined').classes('w-40') \
                     .tooltip('Choose the row number you would like to give a fixed support point to.') \
                     .bind_value(self, 'row_name')
@@ -99,7 +99,7 @@ class SupportPointDialog:
         if field is None:
             ui.notify('No field selected.')
             return
-        row_index = (self.bed_number - 1) * field.row_count + self.row_name - 1
+        row_index = (self.bed_number) * field.row_count + self.row_name
         row_support_point = RowSupportPoint.from_geopoint(self.support_point_coordinates, row_index)
         self.field_provider.add_row_support_point(field.id, row_support_point)
         ui.notify('Support point added.')

--- a/field_friend/interface/components/support_point_dialog.py
+++ b/field_friend/interface/components/support_point_dialog.py
@@ -55,21 +55,21 @@ class SupportPointDialog:
             if self.field_provider.selected_field and self.field_provider.selected_field.bed_count == 1:
                 ui.label('2. Enter the row number for the support point:').classes('text-lg')
                 ui.number(
-                    label='Row Number', min=0, max=self.field_provider.selected_field.row_count - 1, step=1, value=1) \
+                    label='Row Number', min=0, max=self.field_provider.selected_field.row_count - 1, step=1, value=0) \
                     .props('dense outlined').classes('w-40') \
                     .tooltip('Choose the row number you would like to give a fixed support point to.') \
                     .bind_value(self, 'row_name')
             elif self.field_provider.selected_field is not None:
                 ui.label('2. Enter the bed and row number for the support point:').classes('text-lg')
                 ui.number(
-                    label='Bed Number', min=0, max=self.field_provider.selected_field.bed_count - 1, step=1, value=1) \
+                    label='Bed Number', min=0, max=self.field_provider.selected_field.bed_count - 1, step=1, value=0) \
                     .props('dense outlined').classes('w-40') \
-                    .tooltip('Choose the bed number the row is on.') \
+                    .tooltip('Choose the bed index the row is on.') \
                     .bind_value(self, 'bed_number')
                 ui.number(
-                    label='Row Number', min=0, max=self.field_provider.selected_field.row_count - 1, step=1, value=1) \
+                    label='Row Number', min=0, max=self.field_provider.selected_field.row_count - 1, step=1, value=0) \
                     .props('dense outlined').classes('w-40') \
-                    .tooltip('Choose the row number you would like to give a fixed support point to.') \
+                    .tooltip('Choose the row index you would like to give a fixed support point to.') \
                     .bind_value(self, 'row_name')
         self.next = self.confirm_support_point
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ class TestField:
             ], crop=self.bed_crops['0'])
         ]
         buffer = self.outline_buffer_width
-        row_offset = self.row_spacing * (self.row_count - 1)
+        row_offset = self.row_spacing * (self.row_count)
         self.outline = [
             self.first_row_start.shift_by(x=-buffer, y=buffer),
             self.first_row_end.shift_by(x=buffer, y=buffer),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ class TestField:
             ], crop=self.bed_crops['0'])
         ]
         buffer = self.outline_buffer_width
-        row_offset = self.row_spacing * (self.row_count) - 1
+        row_offset = self.row_spacing * (self.row_count - 1)
         self.outline = [
             self.first_row_start.shift_by(x=-buffer, y=buffer),
             self.first_row_end.shift_by(x=buffer, y=buffer),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,25 +80,25 @@ class TestField:
         }
         self.row_support_points = []
         self.rows = [
-            Row(id=f'field_{self.id}_row_1', name='row_1', points=[
+            Row(id=f'field_{self.id}_row_0', name='row_0', points=[
                 self.first_row_start,
                 self.first_row_end
             ], crop=self.bed_crops['0']),
-            Row(id=f'field_{self.id}_row_2', name='row_2', points=[
+            Row(id=f'field_{self.id}_row_1', name='row_1', points=[
                 self.first_row_start.shift_by(x=0, y=-0.45),
                 self.first_row_end.shift_by(x=0, y=-0.45)
             ], crop=self.bed_crops['0']),
-            Row(id=f'field_{self.id}_row_3', name='row_3', points=[
+            Row(id=f'field_{self.id}_row_2', name='row_2', points=[
                 self.first_row_start.shift_by(x=0, y=-0.9),
                 self.first_row_end.shift_by(x=0, y=-0.9)
             ], crop=self.bed_crops['0']),
-            Row(id=f'field_{self.id}_row_4', name='row_4', points=[
+            Row(id=f'field_{self.id}_row_3', name='row_3', points=[
                 self.first_row_start.shift_by(x=0, y=-1.35),
                 self.first_row_end.shift_by(x=0, y=-1.35)
             ], crop=self.bed_crops['0'])
         ]
         buffer = self.outline_buffer_width
-        row_offset = self.row_spacing * (self.row_count)
+        row_offset = self.row_spacing * (self.row_count) - 1
         self.outline = [
             self.first_row_start.shift_by(x=-buffer, y=buffer),
             self.first_row_end.shift_by(x=buffer, y=buffer),

--- a/tests/test_field_creator.py
+++ b/tests/test_field_creator.py
@@ -35,7 +35,7 @@ def test_field_creation_wrong_row_spacing(system: System, field_creator: FieldCr
 def test_support_point_dialog(system: System, field: Field):
     dialog = SupportPointDialog(system)
     row_index = 2
-    dialog.row_name = row_index+1
+    dialog.row_name = row_index
     test_location = FIELD_FIRST_ROW_START.shift_by(x=0, y=-1.5)
     system.gnss.last_measurement.pose = GeoPose(lat=test_location.lat, lon=test_location.lon, heading=0)
     dialog.next()

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -56,7 +56,7 @@ def test_field_outline(system: System, field: Field):
         assert rounded_geo_point(point) in [rounded_geo_point(p) for p in outline]
 
     buffer = field.outline_buffer_width
-    row_offset = field.row_spacing * (field.row_count)
+    row_offset = field.row_spacing * (field.row_count) - 1
 
     # Check first row boundary points
     assert_in_outline(field.first_row_start.shift_by(x=-buffer, y=buffer))
@@ -260,7 +260,7 @@ def test_create_field_with_multiple_beds(system: System, field: Field):
     # Test second bed rows
     for i in range(row_count):
         row_index = i + row_count
-        y_offset = -((row_index) * row_spacing + bed_spacing)
+        y_offset = -((row_index - 1) * row_spacing + bed_spacing)
         expected_start = field_with_beds.first_row_start.shift_by(x=0, y=y_offset)
         expected_end = field_with_beds.first_row_end.shift_by(x=0, y=y_offset)
         assert created_field.rows[row_index].points[0].lat == pytest.approx(expected_start.lat, abs=1e-8)

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -259,8 +259,8 @@ def test_create_field_with_multiple_beds(system: System, field: Field):
     assert created_field.rows[2].points[0].lat == pytest.approx(FIELD_FIRST_ROW_START.lat, abs=1e-8)
     # Test second bed rows
     for i in range(row_count):
-        row_index = i + row_count - 1
-        y_offset = -(row_index * row_spacing + bed_spacing)
+        row_index = i + row_count
+        y_offset = -((row_index - 1) * row_spacing + bed_spacing)
         expected_start = field_with_beds.first_row_start.shift_by(x=0, y=y_offset)
         expected_end = field_with_beds.first_row_end.shift_by(x=0, y=y_offset)
         assert created_field.rows[row_index].points[0].lat == pytest.approx(expected_start.lat, abs=1e-8)

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -56,7 +56,7 @@ def test_field_outline(system: System, field: Field):
         assert rounded_geo_point(point) in [rounded_geo_point(p) for p in outline]
 
     buffer = field.outline_buffer_width
-    row_offset = field.row_spacing * (field.row_count) - 1
+    row_offset = field.row_spacing * (field.row_count - 1)
 
     # Check first row boundary points
     assert_in_outline(field.first_row_start.shift_by(x=-buffer, y=buffer))

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -259,8 +259,8 @@ def test_create_field_with_multiple_beds(system: System, field: Field):
     assert created_field.rows[2].points[0].lat == pytest.approx(FIELD_FIRST_ROW_START.lat, abs=1e-8)
     # Test second bed rows
     for i in range(row_count):
-        row_index = i + row_count
-        y_offset = -((row_index - 1) * row_spacing + bed_spacing)
+        row_index = i + row_count - 1
+        y_offset = -(row_index * row_spacing + bed_spacing)
         expected_start = field_with_beds.first_row_start.shift_by(x=0, y=y_offset)
         expected_end = field_with_beds.first_row_end.shift_by(x=0, y=y_offset)
         assert created_field.rows[row_index].points[0].lat == pytest.approx(expected_start.lat, abs=1e-8)

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -56,7 +56,7 @@ def test_field_outline(system: System, field: Field):
         assert rounded_geo_point(point) in [rounded_geo_point(p) for p in outline]
 
     buffer = field.outline_buffer_width
-    row_offset = field.row_spacing * (field.row_count - 1)
+    row_offset = field.row_spacing * (field.row_count)
 
     # Check first row boundary points
     assert_in_outline(field.first_row_start.shift_by(x=-buffer, y=buffer))
@@ -260,7 +260,7 @@ def test_create_field_with_multiple_beds(system: System, field: Field):
     # Test second bed rows
     for i in range(row_count):
         row_index = i + row_count
-        y_offset = -((row_index-1) * row_spacing + bed_spacing)
+        y_offset = -((row_index) * row_spacing + bed_spacing)
         expected_start = field_with_beds.first_row_start.shift_by(x=0, y=y_offset)
         expected_end = field_with_beds.first_row_end.shift_by(x=0, y=y_offset)
         assert created_field.rows[row_index].points[0].lat == pytest.approx(expected_start.lat, abs=1e-8)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -489,7 +489,7 @@ async def test_complete_field_with_selected_beds(system: System, field_with_beds
     assert system.gnss.last_measurement.point.distance(ROBOT_GEO_START_POSITION) < 0.01
     system.field_provider.select_field(field_with_beds.id)
     system.field_provider.only_specific_beds = True
-    system.field_provider.selected_beds = [1, 3]
+    system.field_provider.selected_beds = [0, 2]
     system.current_navigation = system.field_navigation
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
@@ -506,7 +506,7 @@ async def test_complete_field_without_second_bed(system: System, field_with_beds
     assert system.gnss.last_measurement.point.distance(ROBOT_GEO_START_POSITION) < 0.01
     system.field_provider.select_field(field_with_beds.id)
     system.field_provider.only_specific_beds = True
-    system.field_provider.selected_beds = [1, 3, 4]
+    system.field_provider.selected_beds = [0, 2, 3]
     system.current_navigation = system.field_navigation
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
@@ -549,7 +549,7 @@ async def test_field_with_bed_crops(system: System, field_with_beds: Field):
         await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FOLLOW_ROW)
         expected_crop = field_with_beds.bed_crops[str(bed_number)]
         assert system.current_implement.cultivated_crop == expected_crop
-        if bed_number != field_with_beds.bed_count:
+        if bed_number != field_with_beds.bed_count - 1:
             await forward(until=lambda: system.field_navigation._state == FieldNavigationState.CHANGE_ROW)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FIELD_COMPLETED, timeout=1500)
     await forward(until=lambda: system.automator.is_stopped)
@@ -615,7 +615,7 @@ async def test_field_with_bed_crops_with_tornado(system_with_tornado: System, fi
                       if obj.category_name != expected_crop
                       and obj.position.y == current_y]
         assert len(wrong_crop) == 1, f'Tornado should have skipped 1 wrong crop in bed {bed_number}'
-        if bed_number != field_with_beds.bed_count:
+        if bed_number != field_with_beds.bed_count - 1:
             await forward(until=lambda: system.field_navigation._state == FieldNavigationState.CHANGE_ROW)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FIELD_COMPLETED, timeout=1500)
     await forward(until=lambda: system.automator.is_stopped)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -549,7 +549,7 @@ async def test_field_with_bed_crops(system: System, field_with_beds: Field):
         await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FOLLOW_ROW)
         expected_crop = field_with_beds.bed_crops[str(bed_number)]
         assert system.current_implement.cultivated_crop == expected_crop
-        if bed_number != field_with_beds.bed_count - 1:
+        if bed_number != field_with_beds.bed_count:
             await forward(until=lambda: system.field_navigation._state == FieldNavigationState.CHANGE_ROW)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FIELD_COMPLETED, timeout=1500)
     await forward(until=lambda: system.automator.is_stopped)
@@ -615,7 +615,7 @@ async def test_field_with_bed_crops_with_tornado(system_with_tornado: System, fi
                       if obj.category_name != expected_crop
                       and obj.position.y == current_y]
         assert len(wrong_crop) == 1, f'Tornado should have skipped 1 wrong crop in bed {bed_number}'
-        if bed_number != field_with_beds.bed_count - 1:
+        if bed_number != field_with_beds.bed_count:
             await forward(until=lambda: system.field_navigation._state == FieldNavigationState.CHANGE_ROW)
     await forward(until=lambda: system.field_navigation._state == FieldNavigationState.FIELD_COMPLETED, timeout=1500)
     await forward(until=lambda: system.automator.is_stopped)


### PR DESCRIPTION
Currently we handle beds and rows for users with a name starting at 1. For a cleaner code we would not just the internal indexes starting at 0 but also the row and bed numbers.