### PR TITLE
Update to RoSys 0.23.0

### DIFF
--- a/field_friend/automations/field_provider.py
+++ b/field_friend/automations/field_provider.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 import rosys
+from rosys.event import Event
 
 from .field import Field, Row, RowSupportPoint
 
@@ -13,11 +14,11 @@ class FieldProvider(rosys.persistence.PersistentModule):
         self.fields: list[Field] = []
         self.needs_backup: bool = False
 
-        self.FIELDS_CHANGED = rosys.event.Event()
+        self.FIELDS_CHANGED: Event = Event()
         """The dict of fields has changed."""
 
         self.selected_field: Field | None = None
-        self.FIELD_SELECTED = rosys.event.Event()
+        self.FIELD_SELECTED: Event = Event()
         """A field has been selected."""
 
         self.only_specific_beds: bool = False

--- a/field_friend/automations/path_provider.py
+++ b/field_friend/automations/path_provider.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import rosys
+from rosys.event import Event
 
 
 @dataclass(slots=True, kw_only=True)
@@ -16,10 +17,10 @@ class PathProvider(rosys.persistence.PersistentModule):
         super().__init__()
         self.paths: list[Path] = []
 
-        self.PATHS_CHANGED = rosys.event.Event()
+        self.PATHS_CHANGED: Event = Event()
         """The dict of paths has changed."""
 
-        self.SHOW_PATH = rosys.event.Event()
+        self.SHOW_PATH: Event[list[rosys.driving.PathSegment]] = Event()
         """Show the path in the map."""
 
         self.needs_backup: bool = False

--- a/field_friend/automations/plant_provider.py
+++ b/field_friend/automations/plant_provider.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import rosys
 from nicegui import ui
+from rosys.event import Event
 from rosys.geometry import Point3d
 
 from .plant import Plant
@@ -39,13 +40,13 @@ class PlantProvider(rosys.persistence.PersistentModule):
         self.minimum_combined_crop_confidence: float = MINIMUM_COMBINED_CROP_CONFIDENCE
         self.minimum_combined_weed_confidence: float = MINIMUM_COMBINED_WEED_CONFIDENCE
 
-        self.PLANTS_CHANGED = rosys.event.Event()
+        self.PLANTS_CHANGED: Event = Event()
         """The collection of plants has changed."""
 
-        self.ADDED_NEW_WEED = rosys.event.Event()
+        self.ADDED_NEW_WEED: Event = Event()
         """A new weed has been added."""
 
-        self.ADDED_NEW_CROP = rosys.event.Event()
+        self.ADDED_NEW_CROP: Event = Event()
         """A new crop has been added."""
 
         rosys.on_repeat(self.prune, 10.0)

--- a/field_friend/hardware/teltonika_router.py
+++ b/field_friend/hardware/teltonika_router.py
@@ -6,6 +6,7 @@ import httpx
 import rosys
 from dotenv import load_dotenv
 from nicegui import ui
+from rosys.event import Event
 
 load_dotenv('.env')
 
@@ -17,7 +18,7 @@ class TeltonikaRouter:
     def __init__(self) -> None:
         super().__init__()
         self.current_connection: str = 'disconnected'
-        self.CONNECTION_CHANGED = rosys.event.Event()
+        self.CONNECTION_CHANGED: Event = Event()
 
         self.log = logging.getLogger('hardware.teltonika_router')
 
@@ -26,7 +27,7 @@ class TeltonikaRouter:
         self.token_time: float = 0.0
         self.connection_check_running = False
         self.mobile_upload_permission = False
-        self.MOBILE_UPLOAD_PERMISSION_CHANGED = rosys.event.Event()
+        self.MOBILE_UPLOAD_PERMISSION_CHANGED: Event = Event()
         if ADMIN_PASSWORD:
             self.log.info('Connecting to Teltonika router...')
             rosys.on_repeat(self.get_current_connection, 1.0)

--- a/field_friend/interface/components/header_bar.py
+++ b/field_friend/interface/components/header_bar.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import rosys
 from nicegui import ui
+from rosys.event import Event
 
 from ...hardware import FieldFriend
 from .manual_steerer_dialog import ManualSteererDialog as manual_steerer_dialog
@@ -17,7 +17,7 @@ class HeaderBar:
         self.system = system
         self.drawer_icon = 'expand_more'
         self.toggled = False
-        self.STATUS_DRAWER_TOGGLED = rosys.event.Event()
+        self.STATUS_DRAWER_TOGGLED: Event = Event()
         '''tells if the status drawer is toggled or not.'''
 
         with ui.header().classes('items-center'):

--- a/field_friend/interface/components/log_monitor.py
+++ b/field_friend/interface/components/log_monitor.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import rosys
 from nicegui import ui
+from rosys.event import Event
 
 
 class LogMonitor(rosys.persistence.PersistentModule):
@@ -13,7 +14,7 @@ class LogMonitor(rosys.persistence.PersistentModule):
         self.max_lines = max_lines
         self.lines: deque[str] = deque([], max_lines)
 
-        self.NEW_LINE = rosys.event.Event()
+        self.NEW_LINE: Event[str] = Event()
         """a new line was added to the log (argument: line)"""
 
         rosys.NEW_NOTIFICATION.register(self.handle_notification)

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -7,6 +7,7 @@ import numpy as np
 import psutil
 import rosys
 from rosys.driving import Odometer
+from rosys.event import Event
 from rosys.geometry import GeoPoint, GeoReference, Pose
 from rosys.hardware.gnss import GnssHardware, GnssSimulation
 
@@ -56,7 +57,7 @@ class System(rosys.persistence.PersistentModule):
         rosys.hardware.SerialCommunication.search_paths.insert(0, '/dev/ttyTHS0')
         self.log = logging.getLogger('field_friend.system')
         self.is_real = rosys.hardware.SerialCommunication.is_possible()
-        self.AUTOMATION_CHANGED = rosys.event.Event()
+        self.AUTOMATION_CHANGED: Event[str] = Event()
 
         self.camera_provider = self.setup_camera_provider()
         self.detector: rosys.vision.DetectorHardware | rosys.vision.DetectorSimulation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 fiona
 geopandas
 geopy
-git+https://github.com/zauberzeug/rosys.git@eaf0939922a5727f732891f35e2a99c7e905830b
 icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-# rosys == v0.23.0
+rosys == v0.23.0
 shapely
 uvicorn == 0.28.1


### PR DESCRIPTION
Update to [RoSys 0.23.0](https://github.com/zauberzeug/rosys/releases/tag/v0.23.0) which includes features that were already needed on main.
https://github.com/zauberzeug/rosys/pull/264 introduced typed events as part of 0.23.0, some events had to be annotated because of it.

Was tested on U4