### PR TITLE
Split up code checker jobs to run them separately

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ jobs:
       matrix:
         tools:
           - command: ["mypy", "./field_friend", "--non-interactive"]
-          - command: ["ruff", "check", "./field_friend"]
+          # - command: ["ruff", "check", "./field_friend"]
+          - command: ["pre-commit", "run", "--all-files"]
           - command: ["pylint", "./field_friend"]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
       matrix:
         tools:
           - command: ["mypy", "./field_friend", "--non-interactive"]
-          # - command: ["ruff", "check", "./field_friend"]
           - command: ["pre-commit", "run", "--all-files"]
           - command: ["pylint", "./field_friend"]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,13 @@ name: Run Tests
 on: [push]
 
 jobs:
-  checker:
+  code-checks:
+    strategy:
+      matrix:
+        tools:
+          - command: ["mypy", "./field_friend", "--non-interactive"]
+          - command: ["ruff", "check", "./field_friend"]
+          - command: ["pylint", "./field_friend"]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -14,16 +20,13 @@ jobs:
           python-version: "3.11"
           cache: "pip"
       - name: install dependencies
-        run: |
-          pip install -r requirements-dev.txt
-      - name: pre-commit, mypy & pylint
-        run: |
-          pre-commit run --all-files
-          mypy ./field_friend --non-interactive
-          # pylint ./field_friend
+        run: pip install -r requirements-dev.txt
+      - name: ${{ matrix.tools.command[0] }}
+        run: ${{ join(matrix.tools.command, ' ') }}
+
   pytest:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Before, if one check failed, all had to be rerun. This PR solves this.

@codingpaula is there an advantage of checking ruff alone and not as part of pre-commit?