### PR TITLE
Make gnss optional and avoid numerical instabilities in simulation

### DIFF
--- a/field_friend/api/automation.py
+++ b/field_friend/api/automation.py
@@ -11,6 +11,11 @@ class Automation:
 
         @app.get('/api/automation/field_navigation/status')
         async def get_field_navigation_status():
+            if self.system.field_navigation is None:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={'error': 'Field navigation is not available'}
+                )
             distance_to_end = self.system.robot_locator.pose.point.distance(
                 self.system.field_navigation.end_point) if self.system.field_navigation.end_point else None
             return JSONResponse(
@@ -27,6 +32,11 @@ class Automation:
 
         @app.post('/api/automation/field_navigation/start')
         async def start_field_navigation(request: Request):
+            if self.system.field_navigation is None:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={'error': 'Field navigation is not available'}
+                )
             try:
                 request_data = await request.json()
                 if 'field_id' not in request_data or 'beds' not in request_data:
@@ -58,6 +68,11 @@ class Automation:
 
         @app.post('/api/automation/field_navigation/confirm_turn')
         async def confirm_turn():
+            if self.system.field_navigation is None:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={'error': 'Field navigation is not available'}
+                )
             self.system.field_navigation.allowed_to_turn = True
             return JSONResponse(
                 status_code=status.HTTP_200_OK,

--- a/field_friend/api/status.py
+++ b/field_friend/api/status.py
@@ -29,8 +29,8 @@ class Status:
                 core_version = 'simulation'
                 p0_version = 'simulation'
             if self.system.automator.is_running or self.system.automator.is_paused:
-                field = self.system.field_navigation.field.name if self.system.field_navigation.field else None
-                row = self.system.field_navigation.current_row.name if self.system.field_navigation.current_row else None
+                field = self.system.field_navigation.field.name if self.system.field_navigation is not None and self.system.field_navigation.field else None
+                row = self.system.field_navigation.current_row.name if self.system.field_navigation is not None and self.system.field_navigation.current_row else None
             else:
                 field = None
                 row = None

--- a/field_friend/api/status.py
+++ b/field_friend/api/status.py
@@ -34,7 +34,7 @@ class Status:
             else:
                 field = None
                 row = None
-            position = self.system.gnss.last_measurement.point.degree_tuple if self.system.gnss.last_measurement is not None else None
+            position = self.system.gnss.last_measurement.point.degree_tuple if self.system.gnss is not None and self.system.gnss.last_measurement is not None else None
             data = {
                 'robot_id': self.system.robot_id,
                 'brain_id': self.system.config.robot_brain.name,
@@ -43,7 +43,7 @@ class Status:
                 'status': work_status,
                 'position': {'lat': position[0], 'lon': position[1]} if position is not None else None,
                 # TODO: update the gnss quality with kalman filter
-                'gnss_quality': self.system.gnss.last_measurement.gps_quality if self.system.gnss.last_measurement is not None else None,
+                'gnss_quality': self.system.gnss.last_measurement.gps_quality if self.system.gnss is not None and self.system.gnss.last_measurement is not None else None,
                 'implement': self.system.field_friend.implement_name,
                 'navigation': self.system.current_navigation.name if self.system.current_navigation is not None else None,
                 'field': field,

--- a/field_friend/automations/automation_watcher.py
+++ b/field_friend/automations/automation_watcher.py
@@ -81,6 +81,7 @@ class AutomationWatcher:
         self.incidence_pose = deepcopy(self.robot_locator.pose)
 
     def is_gnss_ready(self) -> bool:
+        assert self.gnss is not None
         return self.gnss.is_connected \
             and self.gnss.last_measurement is not None \
             and rosys.time() - self.gnss.last_measurement.time < 2.0 \

--- a/field_friend/automations/implements/weeding_implement.py
+++ b/field_friend/automations/implements/weeding_implement.py
@@ -54,6 +54,7 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
             rosys.notify('Dectection model information not available', 'negative')
             return False
         if self.cultivated_crop_select is not None:
+            self.log.warning('setting cultivated crop options')
             self.cultivated_crop_select.set_options(self.system.plant_locator.crop_category_names)
         self.log.info(f'start weeding {self.relevant_weeds} with {self.name} ...')
         self.request_backup()
@@ -193,6 +194,7 @@ class WeedingImplement(Implement, rosys.persistence.PersistentModule):
         async def update_cultivated_crop() -> None:
             assert self.cultivated_crop_select is not None
             if self.cultivated_crop_select.options:
+                self.log.debug('crop options already set')
                 return
             await self.system.plant_locator.fetch_detector_info()
             self.cultivated_crop_select.set_options(self.system.plant_locator.crop_category_names)

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -80,7 +80,7 @@ class FieldNavigation(StraightLineNavigation):
         if not self.rows_to_work_on or len(self.rows_to_work_on) == 0:
             rosys.notify('No rows available', 'negative')
             return False
-        if not self.gnss.is_connected:
+        if self.gnss is None or not self.gnss.is_connected:
             rosys.notify('GNSS is not available', 'negative')
             return False
         for idx, row in enumerate(self.rows_to_work_on):
@@ -107,6 +107,7 @@ class FieldNavigation(StraightLineNavigation):
 
     def get_nearest_row(self) -> Row | None:
         assert self.field is not None
+        assert self.gnss is not None
         assert self.gnss.is_connected
         if self.force_first_row_start:
             self.row_index = 0

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -143,7 +143,9 @@ class Navigation(rosys.persistence.PersistentModule):
             .tooltip(f'Forward speed limit in m/s (default: {self.LINEAR_SPEED_LIMIT:.2f})')
 
 
-def is_reference_valid(gnss: Gnss, *, max_distance: float = 5000.0) -> bool:
+def is_reference_valid(gnss: Gnss | None, *, max_distance: float = 5000.0) -> bool:
+    if gnss is None:
+        return True
     if GeoReference.current is None:
         return False
     if gnss.last_measurement is None:

--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -245,5 +245,5 @@ class PlantLocator(EntityLocator):
         self.crop_category_names.update({crop_name: crop_name.replace('_', ' ').title()
                                         for crop_name in filtered_crops})
         self.detector_info = detector_info
-        self.log.debug('Fetched detector info: %s', detector_info)
+        self.log.debug('Fetched detector info: %s and crops: %s', detector_info, self.crop_category_names)
         return True

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -44,6 +44,7 @@ class FieldCreator:
         self.default_crop: str | None = None
         self.m: ui.leaflet
         self.robot_marker: Marker | None = None
+        assert self.gnss is not None
         self.gnss.NEW_MEASUREMENT.register_ui(self.new_gnss_measurement)
         with ui.dialog() as self.dialog, ui.card().style('width: 900px; max-width: none'):
             with ui.row().classes('w-full no-wrap no-gap'):
@@ -75,6 +76,7 @@ class FieldCreator:
         self.next = self.find_row_ending
 
     def find_row_ending(self) -> None:
+        assert self.gnss is not None
         assert self.gnss.last_measurement is not None
         self.first_row_start = self.gnss.last_measurement.pose.point
         assert self.first_row_start is not None
@@ -95,6 +97,7 @@ class FieldCreator:
         self.next = self.field_infos
 
     def field_infos(self) -> None:
+        assert self.gnss is not None
         assert self.gnss.last_measurement is not None
         self.first_row_end = self.gnss.last_measurement.pose.point
         assert self.first_row_end is not None
@@ -149,6 +152,7 @@ class FieldCreator:
             self.next = self.confirm_geometry
 
     def crop_infos(self) -> None:
+        assert self.gnss is not None
         assert self.gnss.last_measurement is not None
         self.first_row_end = self.gnss.last_measurement.pose.point
         assert self.first_row_end is not None
@@ -170,6 +174,7 @@ class FieldCreator:
         self.next = self.confirm_geometry
 
     def confirm_geometry(self) -> None:
+        assert self.gnss is not None
         self.headline.text = 'Confirm Geometry'
         self.content.clear()
         with self.content.style('max-height: 100%; overflow-y: auto'):
@@ -193,6 +198,7 @@ class FieldCreator:
         self.next = self._apply
 
     def _apply(self) -> None:
+        assert self.gnss is not None
         self.dialog.close()
         if self.first_row_start is None or self.first_row_end is None:
             ui.notify('No valid field parameters.')
@@ -231,8 +237,8 @@ class FieldCreator:
         self.row_sight.set_source(self.back_cam.get_latest_image_url())
 
     def ab_line_map(self) -> None:
-        if self.gnss.last_measurement is None:
-            return
+        assert self.gnss is not None
+        assert self.gnss.last_measurement is not None
         self.m = ui.leaflet(self.gnss.last_measurement.pose.point.degree_tuple).classes('w-full min-h-[500px]')
         if self.first_row_start is not None and self.first_row_end is not None:
             self.m.generic_layer(name='polyline', args=[

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -59,6 +59,9 @@ class FieldCreator:
         self.open()
 
     def open(self) -> None:
+        if self.gnss is None or self.gnss.last_measurement is None:
+            rosys.notify('GNSS not available', 'negative')
+            return
         self.next()
         self.dialog.open()
 

--- a/field_friend/interface/components/leaflet_map.py
+++ b/field_friend/interface/components/leaflet_map.py
@@ -34,7 +34,7 @@ class LeafletMap:
             'edit': False,
         }
         center_point = GeoPoint.from_degrees(51.983159, 7.434212)
-        if self.system.gnss.last_measurement is not None:
+        if self.system.gnss is not None and self.system.gnss.last_measurement is not None:
             center_point = self.system.gnss.last_measurement.point
         self.m: ui.leaflet
         if draw_tools:
@@ -53,7 +53,8 @@ class LeafletMap:
         self.field_provider.FIELDS_CHANGED.register_ui(self.update_layers)
         self.field_provider.FIELD_SELECTED.register_ui(self.update_layers)
 
-        self.gnss.NEW_MEASUREMENT.register_ui(self.update_robot_position)
+        if self.gnss is not None:
+            self.gnss.NEW_MEASUREMENT.register_ui(self.update_robot_position)
 
     def buttons(self) -> None:
         """Builds additional buttons to interact with the map."""
@@ -102,8 +103,8 @@ class LeafletMap:
         self.robot_marker.move(*measurement.point.degree_tuple)
 
     def zoom_to_robot(self) -> None:
-        if self.gnss.last_measurement is None:
-            self.log.warning('No GNSS position available, could not zoom to robot')
+        if self.gnss is None or self.gnss.last_measurement is None:
+            self.log.debug('No GNSS position available, could not zoom to robot')
             return
         self.m.set_center(self.gnss.last_measurement.point.degree_tuple)
         if self.current_basemap is not None:

--- a/field_friend/interface/components/support_point_dialog.py
+++ b/field_friend/interface/components/support_point_dialog.py
@@ -75,6 +75,7 @@ class SupportPointDialog:
         self.next = self.confirm_support_point
 
     def confirm_support_point(self) -> None:
+        assert self.gnss is not None
         assert self.gnss.last_measurement is not None
         if self.gnss.last_measurement.gps_quality != GpsQuality.RTK_FIXED:
             with self.content:

--- a/field_friend/interface/dev_page.py
+++ b/field_friend/interface/dev_page.py
@@ -70,8 +70,9 @@ class DevPage:
             if isinstance(self.system.field_friend.imu, rosys.hardware.Imu):
                 with ui.card():
                     self.system.field_friend.imu.developer_ui()
-            with ui.card():
-                self.system.field_navigation.developer_ui()
+            if self.system.field_navigation is not None:
+                with ui.card():
+                    self.system.field_navigation.developer_ui()
         if isinstance(self.system.field_friend, rosys.hardware.RobotHardware):
             with ui.row():
                 with ui.card().style('min-width: 200px;'):

--- a/field_friend/interface/dev_page.py
+++ b/field_friend/interface/dev_page.py
@@ -64,8 +64,9 @@ class DevPage:
                 self.odometer_ui()
                 if isinstance(self.system.field_friend.wheels, rosys.hardware.WheelsSimulation):
                     self.wheels_ui()
-            with ui.card():
-                self.system.gnss.developer_ui()
+            if self.system.gnss is not None:
+                with ui.card():
+                    self.system.gnss.developer_ui()
             if isinstance(self.system.field_friend.imu, rosys.hardware.Imu):
                 with ui.card():
                     self.system.field_friend.imu.developer_ui()

--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -15,7 +15,7 @@ class RobotLocator(rosys.persistence.PersistentModule):
     R_IMU_ANGULAR = 0.01
     ODOMETRY_ANGULAR_WEIGHT = 0.1
 
-    def __init__(self, wheels: Wheels, gnss: Gnss, imu: Imu | None = None) -> None:
+    def __init__(self, wheels: Wheels, gnss: Gnss | None = None, imu: Imu | None = None) -> None:
         """ Robot Locator based on an extended Kalman filter."""
         super().__init__(persistence_key='field_friend.robot_locator')
         self.log = logging.getLogger('field_friend.robot_locator')
@@ -43,7 +43,8 @@ class RobotLocator(rosys.persistence.PersistentModule):
         self._previous_imu_measurement: ImuMeasurement | None = None
 
         self._wheels.VELOCITY_MEASURED.register(self._handle_velocity_measurement)
-        self._gnss.NEW_MEASUREMENT.register(self._handle_gnss_measurement)
+        if self._gnss is not None:
+            self._gnss.NEW_MEASUREMENT.register(self._handle_gnss_measurement)
 
     def backup(self) -> dict[str, Any]:
         return {

--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -32,8 +32,8 @@ class RobotLocator(rosys.persistence.PersistentModule):
         self._pose_timestamp = rosys.time()
 
         # bound attributes
-        self._ignore_gnss = False
-        self._ignore_imu = False
+        self._ignore_gnss = True if gnss is None else False
+        self._ignore_imu = True if imu is None else False
         self._r_odom_linear = self.R_ODOM_LINEAR
         self._r_odom_angular = self.R_ODOM_ANGULAR
         self._r_imu_angular = self.R_IMU_ANGULAR

--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -32,8 +32,8 @@ class RobotLocator(rosys.persistence.PersistentModule):
         self._pose_timestamp = rosys.time()
 
         # bound attributes
-        self._ignore_gnss = True if gnss is None else False
-        self._ignore_imu = True if imu is None else False
+        self._ignore_gnss = gnss is None
+        self._ignore_imu = imu is None
         self._r_odom_linear = self.R_ODOM_LINEAR
         self._r_odom_angular = self.R_ODOM_ANGULAR
         self._r_imu_angular = self.R_IMU_ANGULAR

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -272,7 +272,9 @@ class System(rosys.persistence.PersistentModule):
         rosys.NEW_NOTIFICATION.register(self.timelapse_recorder.notify)
         rosys.on_startup(self.timelapse_recorder.compress_video)  # NOTE: cleanup JPEGs from before last shutdown
 
-    def setup_gnss(self, wheels: rosys.hardware.WheelsSimulation | None = None) -> GnssHardware | GnssSimulation:
+    def setup_gnss(self, wheels: rosys.hardware.WheelsSimulation | None = None) -> GnssHardware | GnssSimulation | None:
+        if self.config.gnss is None:
+            return None
         if self.is_real:
             # handle the case where the gnss is not configured
             assert self.config.gnss is not None

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -56,7 +56,7 @@ class System(rosys.persistence.PersistentModule):
         self.camera_provider = self.setup_camera_provider()
         self.detector: rosys.vision.DetectorHardware | rosys.vision.DetectorSimulation
         self.update_gnss_reference(reference=GeoReference(GeoPoint.from_degrees(51.983204032849706, 7.434321368936861)))
-        self.gnss: GnssHardware | GnssSimulation
+        self.gnss: GnssHardware | GnssSimulation | None
         self.field_friend: FieldFriend
         self._current_navigation: Navigation | None = None
         self.implements: dict[str, Implement] = {}

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -278,7 +278,7 @@ class System(rosys.persistence.PersistentModule):
             assert self.config.gnss is not None
             return GnssHardware(antenna_pose=self.config.gnss.antenna_pose)
         assert isinstance(wheels, rosys.hardware.WheelsSimulation)
-        return GnssSimulation(wheels=wheels, lat_std_dev=0.001, lon_std_dev=0.001, heading_std_dev=0.01)
+        return GnssSimulation(wheels=wheels, lat_std_dev=1e-10, lon_std_dev=1e-10, heading_std_dev=1e-10)
 
     def update_gnss_reference(self, *, reference: GeoReference | None = None) -> None:
         if reference is None:

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -55,8 +55,8 @@ class System(rosys.persistence.PersistentModule):
 
         self.camera_provider = self.setup_camera_provider()
         self.detector: rosys.vision.DetectorHardware | rosys.vision.DetectorSimulation
-        self.gnss: GnssHardware | GnssSimulation | None = None
         self.update_gnss_reference(reference=GeoReference(GeoPoint.from_degrees(51.983204032849706, 7.434321368936861)))
+        self.gnss: GnssHardware | GnssSimulation | None = None
         self.field_friend: FieldFriend
         self._current_navigation: Navigation | None = None
         self.implements: dict[str, Implement] = {}
@@ -281,10 +281,10 @@ class System(rosys.persistence.PersistentModule):
         return GnssSimulation(wheels=wheels, lat_std_dev=1e-10, lon_std_dev=1e-10, heading_std_dev=1e-10)
 
     def update_gnss_reference(self, *, reference: GeoReference | None = None) -> None:
-        if self.gnss is None:
-            self.log.warning('Not updating GNSS reference: GNSS not configured')
-            return
         if reference is None:
+            if self.gnss is None:
+                self.log.warning('Not updating GNSS reference: GNSS not configured')
+                return
             if self.gnss.last_measurement is None:
                 self.log.warning('Not updating GNSS reference: No GNSS measurement received')
                 return

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -276,8 +276,6 @@ class System(rosys.persistence.PersistentModule):
         if self.config.gnss is None:
             return None
         if self.is_real:
-            # handle the case where the gnss is not configured
-            assert self.config.gnss is not None
             return GnssHardware(antenna_pose=self.config.gnss.antenna_pose)
         assert isinstance(wheels, rosys.hardware.WheelsSimulation)
         return GnssSimulation(wheels=wheels, lat_std_dev=1e-10, lon_std_dev=1e-10, heading_std_dev=1e-10)

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -278,7 +278,7 @@ class System(rosys.persistence.PersistentModule):
             assert self.config.gnss is not None
             return GnssHardware(antenna_pose=self.config.gnss.antenna_pose)
         assert isinstance(wheels, rosys.hardware.WheelsSimulation)
-        return GnssSimulation(wheels=wheels, lat_std_dev=0.0, lon_std_dev=0.0, heading_std_dev=0.0)
+        return GnssSimulation(wheels=wheels, lat_std_dev=0.001, lon_std_dev=0.001, heading_std_dev=0.01)
 
     def update_gnss_reference(self, *, reference: GeoReference | None = None) -> None:
         if reference is None:


### PR DESCRIPTION
This PR solves three issues and adds some convenient logging:

1. The `RobotLocator` would fail if `gnss` was None, this PR only registers to `Gnss.NEW_MEASUREMENT` if `gnss` is present. A lot of checks all around the codebase were necessary
2. Setting the standard deviations to zero leads to numerical instabilities in the covariance matrix, so 1e-10 is used
3. The `_ignore_gnss` and `_ignore_imu` are now set to `True` if the sensor is `None`

Was tested on U4