### PR TITLE
Add low bandwidth page

### DIFF
--- a/field_friend/interface/__init__.py
+++ b/field_friend/interface/__init__.py
@@ -1,6 +1,7 @@
 from .bms_page import BmsPage as bms_page
 from .dev_page import DevPage as dev_page
 from .kpi_page import KpiPage as kpi_page
+from .low_bandwidth_page import LowBandwidthPage as low_bandwidth_page
 from .main_page import MainPage as main_page
 from .monitor_page import MonitorPage as monitor_page
 
@@ -10,4 +11,5 @@ __all__ = [
     'kpi_page',
     'main_page',
     'monitor_page',
+    'low_bandwidth_page',
 ]

--- a/field_friend/interface/components/header_bar.py
+++ b/field_friend/interface/components/header_bar.py
@@ -38,7 +38,7 @@ class HeaderBar:
             with ui.row():
                 # ui.link('Field planner', '/field').classes('text-white text-lg !no-underline')
                 ui.link('Circle Sight', '/monitor').classes('text-white text-lg !no-underline')
-                # ui.link('Development', '/dev').classes('text-white text-lg !no-underline')
+                ui.link('Low Bandwidth', '/lb').classes('text-white text-lg !no-underline')
 
             ui.button('Manual Steering', on_click=lambda system=system: manual_steerer_dialog(system)).tooltip(
                 'Open the manual steering window to move the robot with a joystick.')

--- a/field_friend/interface/low_bandwidth_page.py
+++ b/field_friend/interface/low_bandwidth_page.py
@@ -40,5 +40,6 @@ class LowBandwidthPage:
                         ui.label('').bind_text_from(self.system.current_navigation,
                                                     'row_index', lambda row_index: f'Row Index: {row_index}')
             with ui.column():
-                track.ui()
+                with ui.row().style('min-height: 37px'):
+                    track.ui()
                 self.log_monitor.ui()

--- a/field_friend/interface/low_bandwidth_page.py
+++ b/field_friend/interface/low_bandwidth_page.py
@@ -1,12 +1,9 @@
 import rosys
-from nicegui import binding, ui
+from nicegui import ui
 from rosys.analysis import track
 
 from ..system import System
-from .components import CameraCard as camera_card
-from .components import LeafletMap as leaflet_map
 from .components import Operation as operation
-from .components import RobotScene as robot_scene
 from .components import create_header
 from .components.log_monitor import LogMonitor
 

--- a/field_friend/interface/low_bandwidth_page.py
+++ b/field_friend/interface/low_bandwidth_page.py
@@ -40,6 +40,6 @@ class LowBandwidthPage:
                         ui.label('').bind_text_from(self.system.current_navigation,
                                                     'row_index', lambda row_index: f'Row Index: {row_index}')
             with ui.column():
-                with ui.row().style('min-height: 37px'):
+                with ui.row().style('height: 37px'):
                     track.ui()
                 self.log_monitor.ui()

--- a/field_friend/interface/low_bandwidth_page.py
+++ b/field_friend/interface/low_bandwidth_page.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 import rosys
 from nicegui import ui
 from rosys.analysis import track
@@ -24,19 +23,22 @@ class LowBandwidthPage:
         page_height = '50vh' if devmode else 'calc(100vh - 170px)'
         ui.colors(primary='#6E93D6', secondary='#53B689', accent='#111B1E', positive='#53B689')
         with ui.row().style(f'height:{page_height}; width: calc(100vw - 2rem); flex-wrap: nowrap;'):
-            with ui.row().classes('h-full ml-2 m-2').style('width: calc(100% - 1rem)'):
-                operation(self.system)
-                with ui.column().classes('h-full').style('width: calc(45% - 2rem); flex-wrap: nowrap;'):
-                    with ui.row().style('margin: 1rem; width: calc(100% - 2rem);'):
-                        with ui.column():
-                            ui.button('emergency stop', on_click=lambda: self.system.field_friend.estop.set_soft_estop(True)).props('color=red') \
-                                .classes('py-3 px-6 text-lg').bind_visibility_from(self.system.field_friend.estop, 'is_soft_estop_active', value=False)
-                            ui.button('emergency reset', on_click=lambda: self.system.field_friend.estop.set_soft_estop(False)) \
-                                .props('color=red-700 outline').classes('py-3 px-6 text-lg') \
-                                .bind_visibility_from(self.system.field_friend.estop, 'is_soft_estop_active', value=True)
-                        ui.space()
+            operation(self.system)
+            with ui.column().classes('h-full').style('width: calc(45% - 2rem); flex-wrap: nowrap;'):
+                with ui.row().style('margin: 1rem; width: calc(100% - 2rem);'):
+                    with ui.column():
+                        ui.button('emergency stop', on_click=lambda: self.system.field_friend.estop.set_soft_estop(True)).props('color=red') \
+                            .classes('py-3 px-6 text-lg').bind_visibility_from(self.system.field_friend.estop, 'is_soft_estop_active', value=False)
+                        ui.button('emergency reset', on_click=lambda: self.system.field_friend.estop.set_soft_estop(False)) \
+                            .props('color=red-700 outline').classes('py-3 px-6 text-lg') \
+                            .bind_visibility_from(self.system.field_friend.estop, 'is_soft_estop_active', value=True)
                         with ui.row():
                             rosys.automation.automation_controls(self.system.automator)
+                    with ui.column().bind_visibility_from(self.system.automator, 'is_running'):
+                        ui.label('').bind_text_from(self.system.current_navigation,
+                                                    '_state', lambda state: f'State: {state.name}')
+                        ui.label('').bind_text_from(self.system.current_navigation,
+                                                    'row_index', lambda row_index: f'Row Index: {row_index}')
             with ui.column():
                 track.ui()
                 self.log_monitor.ui()

--- a/field_friend/interface/low_bandwidth_page.py
+++ b/field_friend/interface/low_bandwidth_page.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 import rosys
 from nicegui import ui
 from rosys.analysis import track

--- a/field_friend/interface/low_bandwidth_page.py
+++ b/field_friend/interface/low_bandwidth_page.py
@@ -1,0 +1,44 @@
+import rosys
+from nicegui import binding, ui
+from rosys.analysis import track
+
+from ..system import System
+from .components import CameraCard as camera_card
+from .components import LeafletMap as leaflet_map
+from .components import Operation as operation
+from .components import RobotScene as robot_scene
+from .components import create_header
+from .components.log_monitor import LogMonitor
+
+
+class LowBandwidthPage:
+
+    def __init__(self, system: System) -> None:
+        self.system = system
+        self.log_monitor = LogMonitor()
+
+        @ui.page('/lb')
+        def page() -> None:
+            create_header(system)
+            self.content(devmode=False)
+
+    def content(self, devmode: bool) -> None:
+        page_height = '50vh' if devmode else 'calc(100vh - 170px)'
+        ui.colors(primary='#6E93D6', secondary='#53B689', accent='#111B1E', positive='#53B689')
+        with ui.row().style(f'height:{page_height}; width: calc(100vw - 2rem); flex-wrap: nowrap;'):
+            with ui.row().classes('h-full ml-2 m-2').style('width: calc(100% - 1rem)'):
+                operation(self.system)
+                with ui.column().classes('h-full').style('width: calc(45% - 2rem); flex-wrap: nowrap;'):
+                    with ui.row().style('margin: 1rem; width: calc(100% - 2rem);'):
+                        with ui.column():
+                            ui.button('emergency stop', on_click=lambda: self.system.field_friend.estop.set_soft_estop(True)).props('color=red') \
+                                .classes('py-3 px-6 text-lg').bind_visibility_from(self.system.field_friend.estop, 'is_soft_estop_active', value=False)
+                            ui.button('emergency reset', on_click=lambda: self.system.field_friend.estop.set_soft_estop(False)) \
+                                .props('color=red-700 outline').classes('py-3 px-6 text-lg') \
+                                .bind_visibility_from(self.system.field_friend.estop, 'is_soft_estop_active', value=True)
+                        ui.space()
+                        with ui.row():
+                            rosys.automation.automation_controls(self.system.automator)
+            with ui.column():
+                track.ui()
+                self.log_monitor.ui()

--- a/field_friend/interface/main_page.py
+++ b/field_friend/interface/main_page.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 import rosys
 from nicegui import binding, ui
 

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def startup() -> None:
     interface.dev_page(system)  # /dev
     interface.monitor_page(system)  # /monitor
     interface.bms_page(system)  # /bms
-
+    interface.low_bandwidth_page(system)  # /lb
     logging_page(['field_friend', 'rosys'])  # /logging
     videos_page()  # /videos
 


### PR DESCRIPTION
When checking our cameras, we noticed that the main page uses up to 250 MB of data per hour. To reduce this, we removed the camera, the Leaflet map, and the robot scene. To still have some idea of what the robot is doing, we are adding the log view and state tracking to this page