### PR TITLE
Reset the robot's position to the gnss position on startup and reset

### DIFF
--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -155,7 +155,8 @@ class RobotLocator(rosys.persistence.PersistentModule):
         z = [[pose.x], [pose.y], [pose.yaw]]
         h = [[self._x[0, 0]], [self._x[1, 0]], [self._x[2, 0]]]
         H = np.eye(3)
-        Q = np.diag([r_xy, r_xy, r_theta])**2
+        variance = np.array([r_xy, r_xy, r_theta], dtype=np.float64)**2
+        Q = np.diag(variance)
         self._update(z=np.array(z), h=np.array(h), H=H, Q=Q)
 
     def _get_local_pose_and_uncertainty(self, gnss_measurement: GnssMeasurement) -> tuple[Pose, float, float]:
@@ -201,7 +202,8 @@ class RobotLocator(rosys.persistence.PersistentModule):
                     'GNSS measurement is not available while resetting position. Activate _ignore_gnss to use zero position.')
                 return
         self._x = np.array([[reset_pose.x, reset_pose.y, reset_pose.yaw]], dtype=float).T
-        self._Sxx = np.diag([r_xy, r_xy, r_theta])**2
+        variance = np.array([r_xy, r_xy, r_theta], dtype=np.float64)**2
+        self._Sxx = np.diag(variance)
         self._update_frame()
         rosys.notify('Positioning initialized', 'positive')
 

--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -145,8 +145,6 @@ class RobotLocator(rosys.persistence.PersistentModule):
 
     def _handle_gnss_measurement(self, gnss_measurement: GnssMeasurement) -> None:
         """Triggers the 'update' step of the Kalman filter."""
-        if not self._first_prediction_done:
-            return
         if self._ignore_gnss:
             return
         if not np.isfinite(gnss_measurement.heading_std_dev):

--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -212,7 +212,7 @@ class RobotLocator(rosys.persistence.PersistentModule):
                 ui.label().bind_text_from(self, '_Sxx', lambda m: f'± {np.rad2deg(m[2, 2]):.2f}°')
             with ui.grid(columns=2).classes('w-full'):
                 ui.checkbox('Ignore GNSS', value=self._ignore_gnss).props('dense color=red').classes('col-span-2') \
-                    .bind_value_to(self, '_ignore_gnss')
+                    .bind_value_to(self, '_ignore_gnss').tooltip('Ignore GNSS measurements. When deactivated, reset the filter for better positioning.')
                 ui.checkbox('Ignore IMU', value=self._ignore_imu).props('dense color=red').classes('col-span-2') \
                     .bind_value_to(self, '_ignore_imu')
                 with ui.column().classes('w-24 gap-0'):


### PR DESCRIPTION
After startup and after resetting the Kalman Filter, the robot did not update it's position and only after driving for some time, it eventually did catch its correct position.

This change now forces an update to find the correct starting position.