### PR TITLE
Save field creator points in app storage

### DIFF
--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -195,11 +195,6 @@ class FieldCreator:
             self.next = self.confirm_geometry
 
     def crop_infos(self) -> None:
-        assert self.gnss is not None
-        assert self.gnss.last_measurement is not None
-        self.first_row_end = self.gnss.last_measurement.pose.point
-        assert self.first_row_end is not None
-
         self.headline.text = 'Crops'
         self.content.clear()
         with self.content:

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -83,12 +83,9 @@ class FieldCreator:
         self.content.clear()
         with self.content:
             rosys.driving.joystick(self.steerer, size=50, color='#6E93D6')
-            ui.label('1. Drive the robot to the leftmost row of your field.').classes(
-                'text-lg')
-            ui.label('2. Place the robot about 1 meter in front of the first crop.').classes(
-                'text-lg')
-            ui.label('• The blue line should be in the center of the row.') \
-                .classes('text-lg ps-8')
+            ui.label('1. Drive the robot to the leftmost row of your field.').classes('text-lg')
+            ui.label('2. Place the robot about 1 meter in front of the first crop.').classes('text-lg')
+            ui.label('• The blue line should be in the center of the row.').classes('text-lg ps-8')
             if self.saved_row_start is not None:
                 ui.separator()
                 ui.label(f'Cached point available: {self.saved_row_start}').classes('text-lg')
@@ -224,7 +221,7 @@ class FieldCreator:
                 with ui.expansion('Crops').classes('w-full'):
                     for i in range(int(self.bed_count)):
                         crop = self.bed_crops[str(i)]
-                        crop_name = self.plant_locator.crop_category_names[crop] if crop is not None else 'No crop selected'
+                        crop_name = 'No crop selected' if crop is None else self.plant_locator.crop_category_names[crop]
                         ui.label(f'Bed {int(i)}: {crop_name}').classes('text-lg')
                 ui.separator()
                 ui.label(f'Row Spacing: {self.row_spacing*100} cm').classes('text-lg')

--- a/field_friend/interface/components/field_creator.py
+++ b/field_friend/interface/components/field_creator.py
@@ -34,8 +34,8 @@ class FieldCreator:
         self.m: ui.leaflet
         self.robot_marker: Marker | None = None
         self.gnss.NEW_MEASUREMENT.register_ui(self._new_gnss_measurement)
-        self.saved_point_a = app.storage.general.get('field_creator_a_point', None)
-        self.saved_point_b = app.storage.general.get('field_creator_b_point', None)
+        self.saved_point_a: tuple[float, float] | None = app.storage.general.get('field_creator_a_point', None)
+        self.saved_point_b: tuple[float, float] | None = app.storage.general.get('field_creator_b_point', None)
         self.first_row_start: GeoPoint | None = None
         self.first_row_end: GeoPoint | None = None
         # default field values


### PR DESCRIPTION
To avoid users having to re-record points if the Field Creator is cancelled, it is now possible to load points from storage. If a point is recorded but no field has been saved yet, it can be used to create the field.