### PR TITLE
Make tornado end stop inversion configurable and use the active property instead of level

### DIFF
--- a/field_friend/config/configuration.py
+++ b/field_friend/config/configuration.py
@@ -407,6 +407,12 @@ class TornadoConfiguration(BaseAxisConfiguration,
     ref_knife_ground_pin_expander: bool = False
     ref_knife_stop_pin_expander: bool = False
     ref_motor_pin_expander: bool = False
+    end_top_inverted: bool = True
+    end_bottom_inverted: bool = True
+    ref_motor_inverted: bool = True
+    ref_gear_inverted: bool = False
+    ref_knife_ground_inverted: bool = False
+    ref_knife_stop_inverted: bool = False
     speed_limit: float = 1.5
     turn_can_address: int = 0x400
     z_can_address: int = 0x500

--- a/field_friend/hardware/tornado.py
+++ b/field_friend/hardware/tornado.py
@@ -133,18 +133,18 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
             bool {config.name}_is_referencing = false
             bool {config.name}_ref_motor_enabled = false
             bool {config.name}_ref_gear_enabled = false
-            when {config.name}_ref_motor_enabled and {config.name}_is_referencing and {config.name}_ref_motor.active == true then
+            when {config.name}_ref_motor_enabled and {config.name}_is_referencing and {config.name}_ref_motor.active then
                 {config.name}_motor_turn.speed(0)
             end
-            when {config.name}_ref_gear_enabled and {config.name}_is_referencing and {config.name}_ref_gear.active == true then
+            when {config.name}_ref_gear_enabled and {config.name}_is_referencing and {config.name}_ref_gear.active then
                 {config.name}_motor_turn.speed(0)
             end
             bool {config.name}_knife_ground_enabled = false
             bool {config.name}_knife_stop_enabled = false
-            when {config.name}_knife_ground_enabled and {config.name}_ref_knife_ground.active == true then
+            when {config.name}_knife_ground_enabled and {config.name}_ref_knife_ground.active then
                 {config.name}_motor_z.off()
             end
-            when {config.name}_knife_stop_enabled and {config.name}_ref_knife_stop.active == true then
+            when {config.name}_knife_stop_enabled and {config.name}_ref_knife_stop.active then
                 {config.name}_motor_z.off()
                 {config.name}_knife_stop_enabled = false
             end

--- a/field_friend/hardware/tornado.py
+++ b/field_friend/hardware/tornado.py
@@ -117,17 +117,17 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
             {config.name}_motor_z.reversed = {'true' if config.is_z_reversed else 'false'}
             {config.name}_motor_turn.reversed = {'true' if config.is_turn_reversed else 'false'}
             {config.name}_end_top = {expander.name + "." if (config.end_stops_on_expander or config.end_top_pin_expander) and expander else ""}Input({config.end_top_pin})
-            {config.name}_end_top.inverted = true
+            {config.name}_end_top.inverted = {'true' if config.end_top_inverted else 'false'}
             {config.name}_end_bottom = {expander.name + "." if (config.end_stops_on_expander or config.end_bottom_pin_expander) and expander else ""}Input({config.end_bottom_pin})
-            {config.name}_end_bottom.inverted = true
+            {config.name}_end_bottom.inverted = {'true' if config.end_bottom_inverted else 'false'}
             {config.name}_ref_motor = {expander.name + "." if (config.end_stops_on_expander or config.ref_motor_pin_expander) and expander else ""}Input({config.ref_motor_pin})
-            {config.name}_ref_motor.inverted = true
+            {config.name}_ref_motor.inverted = {'true' if config.ref_motor_inverted else 'false'}
             {config.name}_ref_gear = {expander.name + "." if (config.end_stops_on_expander or config.ref_gear_pin_expander) and expander else ""}Input({config.ref_gear_pin})
-            {config.name}_ref_gear.inverted = false
+            {config.name}_ref_gear.inverted = {'true' if config.ref_gear_inverted else 'false'}
             {config.name}_ref_knife_stop = {expander.name + "." if (config.end_stops_on_expander or config.ref_knife_stop_pin_expander) and expander else ""}Input({config.ref_knife_stop_pin})
-            {config.name}_ref_knife_stop.inverted = false
+            {config.name}_ref_knife_stop.inverted = {'true' if config.ref_knife_stop_inverted else 'false'}
             {config.name}_ref_knife_ground = {expander.name + "." if (config.end_stops_on_expander or config.ref_knife_ground_pin_expander) and expander else ""}Input({config.ref_knife_ground_pin})
-            {config.name}_ref_knife_ground.inverted = true
+            {config.name}_ref_knife_ground.inverted = {'true' if config.ref_knife_ground_inverted else 'false'}
             {config.name}_z = {expander.name + "." if config.motor_on_expander and expander else ""}MotorAxis({config.name}_motor_z, {config.name + "_end_bottom" if config.is_z_reversed else config.name + "_end_top"}, {config.name + "_end_top" if config.is_z_reversed else config.name + "_end_bottom"})
 
             bool {config.name}_is_referencing = false

--- a/field_friend/hardware/tornado.py
+++ b/field_friend/hardware/tornado.py
@@ -133,18 +133,18 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
             bool {config.name}_is_referencing = false
             bool {config.name}_ref_motor_enabled = false
             bool {config.name}_ref_gear_enabled = false
-            when {config.name}_ref_motor_enabled and {config.name}_is_referencing and {config.name}_ref_motor.level == 0 then
+            when {config.name}_ref_motor_enabled and {config.name}_is_referencing and {config.name}_ref_motor.active == true then
                 {config.name}_motor_turn.speed(0)
             end
-            when {config.name}_ref_gear_enabled and {config.name}_is_referencing and {config.name}_ref_gear.level == 1 then
+            when {config.name}_ref_gear_enabled and {config.name}_is_referencing and {config.name}_ref_gear.active == true then
                 {config.name}_motor_turn.speed(0)
             end
             bool {config.name}_knife_ground_enabled = false
             bool {config.name}_knife_stop_enabled = false
-            when {config.name}_knife_ground_enabled and {config.name}_ref_knife_ground.level == 1 then
+            when {config.name}_knife_ground_enabled and {config.name}_ref_knife_ground.active == true then
                 {config.name}_motor_z.off()
             end
-            when {config.name}_knife_stop_enabled and {config.name}_ref_knife_stop.level == 1 then
+            when {config.name}_knife_stop_enabled and {config.name}_ref_knife_stop.active == true then
                 {config.name}_motor_z.off()
                 {config.name}_knife_stop_enabled = false
             end


### PR DESCRIPTION
- [x] Make tornado end stop inversion configurable
- [x] Set ref_knife_ground_inverted to False, because it was configured wrong on all robots
- [x] Use the active property in lizard

<details>

<summary>ref_knife_ground_inverted tests</summary>

With U4, F12 and F13 I did the same test to check whether the knife end stop is inverted or not, which shows that they should not be inverted.

In the air: 
```
> tornado_ref_knife_ground.inverted
true
> tornado_ref_knife_ground.level
0
> tornado_ref_knife_ground.active
true
```

On the ground:
```
> tornado_ref_knife_ground.level
1
> tornado_ref_knife_ground.active
false
```
</details>



<details>

<summary>Active property</summary>

`ref_motor_inverted` is `True`, so
```
ref_motor.level == 0
```
becomes
```
ref_motor.active == true
```

-------

`ref_gear_inverted` is `False`, so
```
ref_gear.level == 1
```
becomes
```
ref_motor.active == true
```
Same for `ref_knife_ground` and `ref_knife_stop`

</details>