### PR TITLE
Adapt tornado safety to knife_ground sensor inversion

### DIFF
--- a/field_friend/hardware/safety.py
+++ b/field_friend/hardware/safety.py
@@ -80,7 +80,7 @@ class SafetyHardware(Safety, rosys.hardware.ModuleHardware):
             lizard_code += f'when {y_axis.config.name}_ref_t.level == 1 then {wheels.config.name if isinstance(wheels, DoubleWheelsHardware) else wheels.name}.speed(0, 0); end\n'
         if isinstance(z_axis, TornadoHardware):
             if isinstance(y_axis, YAxisStepperHardware | YAxisCanOpenHardware):
-                lizard_code += f'when {z_axis.config.name}_ref_knife_ground.active == false then \
+                lizard_code += f'when {z_axis.config.name}_ref_knife_ground.active then \
                     {wheels.config.name if isinstance(wheels, DoubleWheelsHardware) else wheels.name}.speed(0, 0); {y_axis.config.name}.stop(); end\n'
 
         # implement watchdog for rosys modules


### PR DESCRIPTION
The tornado safety was forgotten in https://github.com/zauberzeug/field_friend/pull/321 which stops both the wheels and the y axis when the tornado blade is in the air.

I will merge this without review, because it's so small and I tested it directly on U4