### PR TITLE
Make enable_esp_on_startup false by default

### DIFF
--- a/field_friend/config/configuration.py
+++ b/field_friend/config/configuration.py
@@ -13,7 +13,7 @@ class RobotBrainConfiguration:
     """
     name: str
     flash_params: list[str]
-    enable_esp_on_startup: bool | None = None
+    enable_esp_on_startup: bool = False
 
 
 @dataclass(kw_only=True)

--- a/field_friend/hardware/field_friend_hardware.py
+++ b/field_friend/hardware/field_friend_hardware.py
@@ -60,11 +60,7 @@ class FieldFriendHardware(FieldFriend, rosys.hardware.RobotHardware):
             self.log.warning('Unknown implement: %s', implement)
 
         communication = rosys.hardware.SerialCommunication()
-        if config.robot_brain.enable_esp_on_startup is not None:
-            robot_brain = rosys.hardware.RobotBrain(communication,
-                                                    enable_esp_on_startup=config.robot_brain.enable_esp_on_startup)
-        else:
-            robot_brain = rosys.hardware.RobotBrain(communication)
+        robot_brain = rosys.hardware.RobotBrain(communication, enable_esp_on_startup=config.robot_brain.enable_esp_on_startup)
         robot_brain.lizard_firmware.flash_params += config.robot_brain.flash_params
 
         bluetooth = rosys.hardware.BluetoothHardware(robot_brain, name=config.name)


### PR DESCRIPTION
While testing [F21](https://github.com/zauberzeug/field_friend/pull/315) we noticed that the Robot Brain did enable the ESP after the start of RoSys, which should not be the case for a new Robot Brain, since they enable it automatically.

[Currently](https://github.com/zauberzeug/rosys/blob/e3524d9c23d721fa797b330c55d02739bb4f2ce7/rosys/hardware/robot_brain.py#L26) the default is `True`, but it will be `False` for all upcoming Robot Brains, so we can set it to that.

@Johannes-Thiel can you check which robots don't enable it automatically? I think F15 is the first one that does.
And please test this with PR with an up to date Robot Brain.