### PR TITLE
Implement `RobotBrain` changes from RoSys #292

### DIFF
--- a/config/u4.py
+++ b/config/u4.py
@@ -18,7 +18,7 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u4',
-    robot_brain=RobotBrainConfiguration(name='rb28', flash_params=['orin']),
+    robot_brain=RobotBrainConfiguration(name='rb28', flash_params=['orin'], use_espresso=True),
     tool='tornado',
     measurements=MeasurementsConfiguration(tooth_count=17, pitch=0.041),
     camera=CameraConfiguration(

--- a/config/u6.py
+++ b/config/u6.py
@@ -17,7 +17,7 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u6',
-    robot_brain=RobotBrainConfiguration(name='rb34', flash_params=['orin', 'v05']),
+    robot_brain=RobotBrainConfiguration(name='rb34', flash_params=['orin', 'v05'], use_espresso=True),
     tool='weed_screw',
     measurements=MeasurementsConfiguration(tooth_count=17, pitch=0.041, work_x=0.085),
     camera=CameraConfiguration(

--- a/field_friend/config/configuration.py
+++ b/field_friend/config/configuration.py
@@ -14,6 +14,7 @@ class RobotBrainConfiguration:
     name: str
     flash_params: list[str]
     enable_esp_on_startup: bool | None = None
+    use_espresso: bool = False
 
 
 @dataclass(kw_only=True)

--- a/field_friend/hardware/field_friend_hardware.py
+++ b/field_friend/hardware/field_friend_hardware.py
@@ -62,9 +62,10 @@ class FieldFriendHardware(FieldFriend, rosys.hardware.RobotHardware):
         communication = rosys.hardware.SerialCommunication()
         if config.robot_brain.enable_esp_on_startup is not None:
             robot_brain = rosys.hardware.RobotBrain(communication,
-                                                    enable_esp_on_startup=config.robot_brain.enable_esp_on_startup)
+                                                    enable_esp_on_startup=config.robot_brain.enable_esp_on_startup,
+                                                    use_espresso=config.robot_brain.use_espresso)
         else:
-            robot_brain = rosys.hardware.RobotBrain(communication)
+            robot_brain = rosys.hardware.RobotBrain(communication, use_espresso=config.robot_brain.use_espresso)
         robot_brain.lizard_firmware.flash_params += config.robot_brain.flash_params
 
         bluetooth = rosys.hardware.BluetoothHardware(robot_brain, name=config.name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-rosys == v0.24.1
+# rosys == v0.24.1
+rosys @ git+https://github.com/zauberzeug/rosys.git@5b4fe4f9cdfa39e1413422d24983bb08637b741e
 shapely
 uvicorn == 0.28.1


### PR DESCRIPTION
Implements https://github.com/zauberzeug/rosys/pull/292
We can now optionale use Lizard's espresso.py and check whether the ESP is connected or not.
@Johannes-Thiel and I already talked about this and I will merge this without review.