### PR TITLE
Add position API endpoints

### DIFF
--- a/field_friend/api/__init__.py
+++ b/field_friend/api/__init__.py
@@ -1,11 +1,13 @@
 from .automation import Automation
 from .fields import Fields
 from .online import Online
+from .position import Position
 from .status import Status
 
 __all__ = [
     'Automation',
     'Fields',
     'Online',
+    'Position',
     'Status',
 ]

--- a/field_friend/api/position.py
+++ b/field_friend/api/position.py
@@ -1,0 +1,73 @@
+import numpy as np
+from fastapi.responses import JSONResponse
+from nicegui import app
+from rosys.geometry import GeoPose, GeoReference
+
+from field_friend.system import System
+
+
+class Position:
+    def __init__(self, system: System) -> None:
+        self.system = system
+
+        @app.get('/api/position/current')
+        async def current():
+            # pylint: disable=protected-access
+            pose = self.system.robot_locator.pose
+            lat, lon, heading = GeoPose.from_pose(pose).degree_tuple
+            data = {
+                'time': pose.time,
+                'local': {
+                    'x': pose.x,
+                    'y': pose.y,
+                    'yaw': pose.yaw_deg,
+                },
+                'uncertainty': {
+                    'x': self.system.robot_locator._Sxx[0, 0],
+                    'y': self.system.robot_locator._Sxx[1, 0],
+                    'yaw': np.deg2rad(self.system.robot_locator._Sxx[2, 0]),
+                },
+                'gnss': {
+                    'lat': lat,
+                    'lon': lon,
+                    'heading': heading,
+                },
+            }
+            return data
+
+        @app.get('/api/position/gnss')
+        async def gnss():
+            if self.system.gnss is None:
+                return JSONResponse(content={'status': 'error', 'message': 'GNSS not available'}, status_code=500)
+            last_measurement = self.system.gnss.last_measurement
+            if last_measurement is None:
+                return JSONResponse(content={'status': 'error', 'message': 'No GNSS measurement available'}, status_code=500)
+            lat, lon, heading = last_measurement.pose.degree_tuple
+            data = {
+                'time': last_measurement.time,
+                'gnss_time': last_measurement.gnss_time,
+                'lat': lat,
+                'lon': lon,
+                'heading': heading,
+                'quality': last_measurement.gps_quality.name.lower(),
+                'num_satellites': last_measurement.num_satellites,
+                'hdop': last_measurement.hdop,
+                'altitude': last_measurement.altitude,
+                'latitude_std_dev': last_measurement.latitude_std_dev,
+                'longitude_std_dev': last_measurement.longitude_std_dev,
+                'heading_std_dev': last_measurement.heading_std_dev,
+            }
+            return data
+
+        @app.get('/api/position/gnss_reference')
+        async def gnss_reference():
+            if GeoReference.current is None:
+                return JSONResponse(content={'status': 'error', 'message': 'GNSS Reference not available'}, status_code=500)
+            lat, lon = GeoReference.current.origin.degree_tuple
+            heading = np.rad2deg(GeoReference.current.direction)
+            data = {
+                'lat': lat,
+                'lon': lon,
+                'heading': heading,
+            }
+            return data

--- a/field_friend/api/position.py
+++ b/field_friend/api/position.py
@@ -27,7 +27,7 @@ class Position:
                     'y': self.system.robot_locator._Sxx[1, 0],
                     'yaw': np.deg2rad(self.system.robot_locator._Sxx[2, 0]),
                 },
-                'gnss': {
+                'geo': {
                     'lat': lat,
                     'lon': lon,
                     'heading': heading,

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ def startup() -> None:
     # API Endpoints
     api.Online()  # get /api/online
     api.Status(system)  # get /api/status
+    api.Position(system)  # get /api/position
     api.Fields(system)  # get,post /api/fields
     api.Automation(system)  # get,post /api/automation/
 


### PR DESCRIPTION
This PR adds three API endpoints that provide information about the current location of the robot.
All distances are in meters and angles in degrees to keep it human readable.

- `/api/position/current` provides both local and geo coordinates calculated by the Kalman Filter.
- `/api/position/gnss` provides the last gnss measurement
- `/api/position/gnss_reference` provides the current geo reference pose to allow the conversion to local coordinates


```
/api/position/current
{
  "time": 1747966041.864919,
  "local": {
    "x": 0.0,
    "y": 0.0,
    "yaw": 0.0
  },
  "uncertainty": {
    "x": 2.5303900313247146e-05,
    "y": 0.0,
    "yaw": 0.0
  },
  "geo": {
    "lat": 51.98302319620841,
    "lon": 7.4343383362250535,
    "heading": 0.0
  }
}
```

```
/api/position/gnss_reference
{
  "time": 1747966067.8288152,
  "gnss_time": 1747966067.8288152,
  "lat": 51.98302319620841,
  "lon": 7.434338336225055,
  "heading": 2.5795194535619837e-11,
  "quality": "rtk_fixed",
  "num_satellites": 0,
  "hdop": 0.0,
  "altitude": 0.0,
  "latitude_std_dev": 1e-10,
  "longitude_std_dev": 1e-10,
  "heading_std_dev": 1e-10
}
```

```
/api/position/gnss_reference
{
  "lat": 51.98302319620841,
  "lon": 7.4343383362250535,
  "heading": 0.0
}
```