### PR TITLE
Make the Canopen axis more robust

### DIFF
--- a/config/u5.py
+++ b/config/u5.py
@@ -18,7 +18,7 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u5',
-    robot_brain=RobotBrainConfiguration(name='rb33', flash_params=['orin', 'v05']),
+    robot_brain=RobotBrainConfiguration(name='rb33', flash_params=['orin', 'v05'], enable_esp_on_startup=True),
     tool='weed_screw',
     measurements=MeasurementsConfiguration(
         tooth_count=17,
@@ -29,7 +29,6 @@ config = FieldFriendConfiguration(
         width=1280,
         height=720,
         fps=10,
-        rotation=90,
         crop=CropConfiguration(left=250, right=250, up=0, down=0),
     ),
     wheels=WheelsConfiguration(

--- a/config/u5.py
+++ b/config/u5.py
@@ -18,7 +18,7 @@ from field_friend.config.configuration import (
 config = FieldFriendConfiguration(
     name='uckerbot-u5',
     robot_brain=RobotBrainConfiguration(name='rb33', flash_params=['orin', 'v05']),
-    tool='recorder',
+    tool='weed_screw',
     measurements=MeasurementsConfiguration(
         tooth_count=17,
         pitch=0.041,

--- a/config/u5.py
+++ b/config/u5.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose
+from rosys.geometry import Pose, Rotation
 
 from field_friend.config.configuration import (
     BumperConfiguration,
@@ -7,6 +7,7 @@ from field_friend.config.configuration import (
     FieldFriendConfiguration,
     FlashlightConfiguration,
     GnssConfiguration,
+    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     WheelsConfiguration,
@@ -57,8 +58,8 @@ config = FieldFriendConfiguration(
         reference_speed=30,
         steps_per_m=1_666_666.667,  # 4000steps/turn motor; 1/10 gear; 0.024m/u
         name='yaxis',
-        max_position=0.125,
-        min_position=-0.125,
+        max_position=0.12,
+        min_position=-0.12,
         version='y_axis_canopen',
     ),
     z_axis=ZCanOpenConfiguration(
@@ -80,6 +81,5 @@ config = FieldFriendConfiguration(
     ),
     circle_sight_positions=CircleSightPositions(),
     gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
-    # TODO: imu not working with 0.5.2
-    imu=None,
+    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6, 0.0261799, -0.0261799)),
 )

--- a/config/u5.py
+++ b/config/u5.py
@@ -4,6 +4,7 @@ from field_friend.config.configuration import (
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,
+    CropConfiguration,
     FieldFriendConfiguration,
     FlashlightConfiguration,
     GnssConfiguration,
@@ -28,6 +29,8 @@ config = FieldFriendConfiguration(
         width=1280,
         height=720,
         fps=10,
+        rotation=90,
+        crop=CropConfiguration(left=250, right=250, up=0, down=0),
     ),
     wheels=WheelsConfiguration(
         is_left_reversed=False,

--- a/config/u5.py
+++ b/config/u5.py
@@ -10,6 +10,8 @@ from field_friend.config.configuration import (
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     WheelsConfiguration,
+    YCanOpenConfiguration,
+    ZCanOpenConfiguration,
 )
 
 config = FieldFriendConfiguration(
@@ -42,8 +44,40 @@ config = FieldFriendConfiguration(
         back_pin=4,
     ),
     bumper=BumperConfiguration(pin_front_top=35, pin_front_bottom=18, pin_back=21),
-    y_axis=None,
-    z_axis=None,
+    y_axis=YCanOpenConfiguration(
+        axis_offset=0.13,
+        reversed_direction=False,
+        end_left_pin=25,
+        end_right_pin=12,
+        end_stops_on_expander=True,
+        motor_on_expander=False,
+        can_address=0x70,
+        end_stops_inverted=True,
+        max_speed=300,
+        reference_speed=30,
+        steps_per_m=1_666_666.667,  # 4000steps/turn motor; 1/10 gear; 0.024m/u
+        name='yaxis',
+        max_position=0.125,
+        min_position=-0.125,
+        version='y_axis_canopen',
+    ),
+    z_axis=ZCanOpenConfiguration(
+        axis_offset=0.0,
+        reversed_direction=False,
+        end_stops_on_expander=True,
+        motor_on_expander=False,
+        end_bottom_pin=23,
+        end_top_pin=22,
+        can_address=0x60,
+        end_stops_inverted=True,
+        max_speed=400,
+        reference_speed=30,
+        steps_per_m=4_000_000,  # 4000steps/turn motor; 1/20 gear; 0.02m/u
+        name='zaxis',
+        max_position=0.0,
+        min_position=-0.197,
+        version='z_axis_canopen',
+    ),
     circle_sight_positions=CircleSightPositions(),
     gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
     # TODO: imu not working with 0.5.2

--- a/config/u5.py
+++ b/config/u5.py
@@ -82,6 +82,6 @@ config = FieldFriendConfiguration(
         version='z_axis_canopen',
     ),
     circle_sight_positions=CircleSightPositions(),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(antenna_pose=Pose(x=0.05165, y=-0.255, yaw=0.0)),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6, 0.0261799, -0.0261799)),
 )

--- a/config/u6.py
+++ b/config/u6.py
@@ -17,7 +17,7 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u6',
-    robot_brain=RobotBrainConfiguration(name='rb34', flash_params=['orin', 'v05']),
+    robot_brain=RobotBrainConfiguration(name='rb34', flash_params=['orin', 'v05'], enable_esp_on_startup=True),
     tool='weed_screw',
     measurements=MeasurementsConfiguration(tooth_count=17, pitch=0.041, work_x=0.085),
     camera=CameraConfiguration(

--- a/field_friend/hardware/y_axis_canopen_hardware.py
+++ b/field_friend/hardware/y_axis_canopen_hardware.py
@@ -1,4 +1,5 @@
 # pylint: disable=broad-exception-raised
+# pylint: disable=duplicate-code
 # TODO: we need a useful exception here
 import rosys
 from rosys.analysis import track

--- a/field_friend/hardware/z_axis_canopen_hardware.py
+++ b/field_friend/hardware/z_axis_canopen_hardware.py
@@ -16,6 +16,9 @@ class ZAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware):
                  expander: rosys.hardware.ExpanderHardware | None) -> None:
         self.config = config
         self.expander = expander
+        self.ctrl_enable = False
+        self.initialized = False
+        self.operational = False
         lizard_code = remove_indentation(f'''
             {config.name}_motor = {expander.name + "." if config.motor_on_expander and expander else ""}CanOpenMotor({can.name}, {config.can_address})
             {config.name}_end_t = {expander.name + "." if config.end_stops_on_expander and expander else ""}Input({config.end_top_pin})
@@ -30,6 +33,9 @@ class ZAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware):
             f'{config.name}_motor.actual_position',
             f'{config.name}_motor.status_target_reached',
             f'{config.name}_motor.status_fault',
+            f'{config.name}_motor.ctrl_enable',
+            f'{config.name}_motor.initialized',
+            f'{config.name}_motor.is_operational',
         ]
         super().__init__(
             max_speed=config.max_speed,
@@ -57,23 +63,24 @@ class ZAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware):
             raise Exception(f'could not move zaxis to {position} because of {error}') from error
         steps = self.compute_steps(position)
         self.log.debug(f'moving to steps: {steps}')
-        await self.enable_motor()
-        await rosys.sleep(0.1)
+        assert self.initialized, 'motor is not initialized'
+        assert self.operational, 'motor is not operational'
+        if not self.ctrl_enable:
+            await self.enable_motor()
+            self.log.info(f'🟢enabled motor: {self.ctrl_enable}')
+            await rosys.sleep(0.3)  # wait for motor to be enabled
+        assert self.ctrl_enable, 'motor is not enabled'
         await self.robot_brain.send(
             f'{self.config.name}.position({steps}, {speed}, 0);'
         )
         # Give flags time to turn false first
         await rosys.sleep(0.2)
         while not self.idle and not self.alarm:
-            await self.robot_brain.send(
-                f'{self.config.name}.position({steps}, {speed}, 0);'
-            )
             await rosys.sleep(0.2)
         if self.alarm:
             self.log.error(f'could not move zaxis to {position} because of fault')
             raise Exception(f'could not move zaxis to {position} because of fault')
         self.log.debug(f'zaxis moved to {position}')
-        await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(false);')
 
     async def enable_motor(self) -> None:
         await self.robot_brain.send(f'{self.config.name}_motor.set_ctrl_enable(true);')
@@ -97,13 +104,18 @@ class ZAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware):
         if not await super().try_reference():
             return False
         try:
-            self.log.info('enabling h motors')
+            assert self.initialized, 'motor is not initialized'
+            assert self.operational, 'motor is not operational'
+            self.log.debug('enabling z motor')
             await self.enable_motor()
+            await rosys.sleep(1)
+            assert self.ctrl_enable, 'motor is not enabled'
             await self.robot_brain.send(
                 f'{self.config.name}_motor.position_offset = 0;'
             )
             await rosys.sleep(1)
-            self.log.info('activating velocity mode')
+            self.log.debug(f'enabled motor: {self.ctrl_enable}')
+            self.log.debug('activating velocity mode')
             await self.robot_brain.send(
                 f'{self.config.name}_motor.enter_pv_mode();'
             )
@@ -185,3 +197,6 @@ class ZAxisCanOpenHardware(Axis, rosys.hardware.ModuleHardware):
         self.alarm = words.pop(0) == 'true'
         if self.alarm:
             self.is_referenced = False
+        self.ctrl_enable = words.pop(0) == 'true'
+        self.initialized = words.pop(0) == 'true'
+        self.operational = words.pop(0) == 'true'

--- a/field_friend/hardware/z_axis_canopen_hardware.py
+++ b/field_friend/hardware/z_axis_canopen_hardware.py
@@ -1,4 +1,5 @@
 # pylint: disable=broad-exception-raised
+# pylint: disable=duplicate-code
 # TODO: we need a useful exception here
 import rosys
 from rosys.analysis import track


### PR DESCRIPTION
**Motivation**

When doing testing on the Canopen axis of `u5` we noticed, that the `z_axis` will sometimes not move upwards after it has drilled. When we did some further investigation we also saw, that sometimes the referncing will not work, when the robot has just started up. This happend without any feedback, as to why it did not work.

**Implementation**

To combat these errors we made the axis more robust with the usage of asserts and handling the static wait times in while loops. The while loops were chosen, in order to make shure that all the nececarry steps are taken in the right order, with dynamic wait times. We are now checking, if the `robot_brain.is_ready`, the motor is `initalized` and if the motor `is_operational`. These checks are made to ensure, that the hardware is ready to work.

**Progress**

- [x] implementation is complete
- [x] tested on u5
- [x] tested in simulation