### PR TITLE
Update ODrive version for U6 to 0.5.6

### DIFF
--- a/config/u6.py
+++ b/config/u6.py
@@ -32,6 +32,7 @@ config = FieldFriendConfiguration(
         left_front_can_address=0x100,
         right_back_can_address=0x200,
         right_front_can_address=0x300,
+        odrive_version=6
     ),
     has_status_control=True,
     flashlight=FlashlightConfiguration(


### PR DESCRIPTION
I flashed the Odrives of u6 with the version of `0.5.6`. To reflect this we need to change the version in the config.