### PR TITLE
change current limit in the config to 35A

### DIFF
--- a/odrive/calibrate_two_motors_l.py
+++ b/odrive/calibrate_two_motors_l.py
@@ -43,7 +43,7 @@ for i, axis in enumerate([odrv0.axis0, odrv0.axis1]):
     print('- Motor configuration')
     assert_equal(axis.motor.config.pole_pairs, 8)
     assert_equal(axis.motor.config.calibration_current, 15)
-    assert_equal(axis.motor.config.current_lim, 20)
+    assert_equal(axis.motor.config.current_lim, 35)
     assert_equal(axis.motor.config.current_lim_margin, 15)
     assert_equal(axis.motor.config.torque_constant, 1.4500000476837158)
     assert_equal(axis.motor.config.torque_lim, 100)

--- a/odrive/calibrate_two_motors_r.py
+++ b/odrive/calibrate_two_motors_r.py
@@ -43,7 +43,7 @@ for i, axis in enumerate([odrv0.axis0, odrv0.axis1]):
     print('- Motor configuration')
     assert_equal(axis.motor.config.pole_pairs, 8)
     assert_equal(axis.motor.config.calibration_current, 15)
-    assert_equal(axis.motor.config.current_lim, 20)
+    assert_equal(axis.motor.config.current_lim, 35)
     assert_equal(axis.motor.config.current_lim_margin, 15)
     assert_equal(axis.motor.config.torque_constant, 1.4500000476837158)
     assert_equal(axis.motor.config.torque_lim, 100)


### PR DESCRIPTION
### Motivation
On some robots we saw worse performance while turning. This was the case due to a increase in `DC_BUS_OVER_CURRENT` errors. To combat this we increase the limit to 35A again.
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

