### PR TITLE
Manually use garbage collection

### DIFF
--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -1,3 +1,4 @@
+import gc
 from enum import Enum, auto
 from random import randint
 from typing import TYPE_CHECKING, Any
@@ -219,7 +220,6 @@ class FieldNavigation(StraightLineNavigation):
         self.allowed_to_turn = False
         return State.FOLLOW_ROW
 
-
     @track
     async def _run_follow_row(self) -> State:
         assert self.end_point is not None
@@ -235,6 +235,7 @@ class FieldNavigation(StraightLineNavigation):
             await self.driver.wheels.stop()
             return State.WAITING_FOR_CONFIRMATION
         if not self.implement.is_active:
+            gc.collect()
             await self.implement.activate()
         self.update_target()
         await self.drive_towards_target(end_pose)

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import gc
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -114,6 +115,7 @@ class Navigation(rosys.persistence.Persistable):
     async def finish(self) -> None:
         """Executed after the navigation is done"""
         self.log.info('Navigation finished')
+        gc.collect()
 
     @abc.abstractmethod
     async def _drive(self) -> None:

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 import os
 from typing import Any
@@ -127,6 +128,8 @@ class System(rosys.persistence.Persistable):
                 self.battery_watcher = BatteryWatcher(self.field_friend, self.automator)
             app_controls(self.field_friend.robot_brain, self.automator, self.field_friend)
             rosys.on_repeat(self.log_status, 60 * 5)
+        rosys.on_repeat(self._garbage_collection, 60*5)
+        rosys.config.garbage_collection_mbyte_limit = 0
 
     def restart(self) -> None:
         os.utime('main.py')
@@ -327,3 +330,8 @@ class System(rosys.persistence.Persistable):
 
         bms_logger = logging.getLogger('field_friend.bms')
         bms_logger.info(f'Battery: {self.field_friend.bms.state.short_string}')
+
+    def _garbage_collection(self):
+        if self.automator.is_running:
+            return
+        gc.collect()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-rosys == v0.25.0
+# rosys == v0.25.0
+rosys @ git+https://github.com/zauberzeug/rosys.git@32c56d3d57f3e2eb5d0ce72b14f36022fb55731d
 shapely
 uvicorn == 0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-# rosys == v0.24.1
-rosys @ git+https://github.com/zauberzeug/rosys.git@7f33591b75aac1d58a9d27c76e6a5e338a8b9f60
+rosys == v0.25.0
 shapely
 uvicorn == 0.28.1


### PR DESCRIPTION
### Motivation
When using the normal rosys garbage collection all functions will be stopped each minute. To prevent this we are calling the garbage collection manually, before enabling the implement when starting a new row and after the automation is finished. If no atomation is running we are starting the garbage collection every 5 minutes.

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation
We choose to use the garbage collection in the `field_navigation.py` at this point, because the robot is standing still while the implement will be enabled. For this reason a second of additional waiting time is okay.
<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
- [x] Wait for https://github.com/zauberzeug/rosys/pull/300
- [x] Also wait for https://github.com/zauberzeug/rosys/pull/302

edit: the commit message "update to RoSys 0.25.1" is not correct, it is an update to 0.25.0
