### PR TITLE
Set the robot's id as detector source

### DIFF
--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -205,7 +205,7 @@ class PlantLocator(EntityLocator):
             @ui.refreshable
             def chips():
                 with ui.row().classes('gap-0'):
-                    ui.chip(self.robot_name).props('outline')
+                    ui.chip(self.robot_id).props('outline')
 
                     def update_tags(tag_to_remove: str) -> None:
                         self.tags.remove(tag_to_remove)

--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -36,7 +36,7 @@ class PlantLocator(EntityLocator):
         self.detector = system.detector
         self.plant_provider = system.plant_provider
         self.robot_locator = system.robot_locator
-        self.robot_name = system.robot_id
+        self.robot_id = system.robot_id
         self.detector_info: DetectorInfo | None = None
         self.tags: list[str] = []
         self.is_paused = True
@@ -106,7 +106,7 @@ class PlantLocator(EntityLocator):
             await rosys.sleep(0.01)
             return
         assert self.detector is not None
-        await self.detector.detect(new_image, autoupload=self.autoupload, tags=[*self.tags, self.robot_name, 'autoupload'])
+        await self.detector.detect(new_image, autoupload=self.autoupload, tags=[*self.tags, self.robot_id, 'autoupload'], source=self.robot_id)
         if rosys.time() - t < 0.01:  # ensure maximum of 100 Hz
             await rosys.sleep(0.01 - (rosys.time() - t))
         if not new_image.detections:

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ def startup() -> None:
         logging.warning(msg)
         ui.label(msg).classes('text-xl')
         return
+    robot_id = robot_id.lower()
     logger.info('Starting Field Friend for robot %s', robot_id)
     system = System(robot_id).persistent()
 


### PR DESCRIPTION
### Motivation

The Learning Loop saves a source for every image. We currently do not use that feature, which is helpful to filter all images by the source.

### Implementation

Just adds the `source`-argument to `Detector.detect`.
I also made sure that `robot_id` is always lowercase.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
