### PR TITLE
Improve Tornado weeding workflow

### DIFF
--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -19,7 +19,7 @@ class Tornado(WeedingImplement):
     DRILL_DEPTH = 0.0
     DRILL_WITH_OPEN_TORNADO = False
     SKIP_IF_NO_WEEDS = False
-    TORNADO_ANGLE = 30.0
+    TORNADO_ANGLE = 180.0
 
     def __init__(self, system: System) -> None:
         super().__init__('Tornado', system)

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -15,18 +15,18 @@ if TYPE_CHECKING:
 
 
 class Tornado(WeedingImplement):
-    TORNADO_ANGLE = 30.0
-    DRILL_WITH_OPEN_TORNADO = False
     DRILL_BETWEEN_CROPS = False
+    DRILL_WITH_OPEN_TORNADO = False
     SKIP_IF_NO_WEEDS = False
+    TORNADO_ANGLE = 30.0
 
     def __init__(self, system: System) -> None:
         super().__init__('Tornado', system)
         self.field_friend = system.field_friend
-        self.tornado_angle: float = self.TORNADO_ANGLE
-        self.drill_with_open_tornado: bool = self.DRILL_WITH_OPEN_TORNADO
         self.drill_between_crops: bool = self.DRILL_BETWEEN_CROPS
+        self.drill_with_open_tornado: bool = self.DRILL_WITH_OPEN_TORNADO
         self.skip_if_no_weeds: bool = self.SKIP_IF_NO_WEEDS
+        self.tornado_angle: float = self.TORNADO_ANGLE
 
     async def start_workflow(self) -> None:
         await super().start_workflow()
@@ -106,16 +106,16 @@ class Tornado(WeedingImplement):
 
     def backup_to_dict(self) -> dict[str, Any]:
         return super().backup_to_dict() | {
-            'drill_with_open_tornado': self.drill_with_open_tornado,
             'drill_between_crops': self.drill_between_crops,
+            'drill_with_open_tornado': self.drill_with_open_tornado,
             'skip_if_no_weeds': self.skip_if_no_weeds,
             'tornado_angle': self.tornado_angle,
         }
 
     def restore_from_dict(self, data: dict[str, Any]) -> None:
         super().restore_from_dict(data)
-        self.drill_with_open_tornado = data.get('drill_with_open_tornado', self.DRILL_WITH_OPEN_TORNADO)
         self.drill_between_crops = data.get('drill_between_crops', self.DRILL_BETWEEN_CROPS)
+        self.drill_with_open_tornado = data.get('drill_with_open_tornado', self.DRILL_WITH_OPEN_TORNADO)
         self.skip_if_no_weeds = data.get('skip_if_no_weeds', self.SKIP_IF_NO_WEEDS)
         self.tornado_angle = data.get('tornado_angle', self.TORNADO_ANGLE)
 

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -15,12 +15,16 @@ if TYPE_CHECKING:
 
 
 class Tornado(WeedingImplement):
+    TORNADO_ANGLE = 30.0
+    DRILL_WITH_OPEN_TORNADO = False
+    DRILL_BETWEEN_CROPS = False
+
     def __init__(self, system: System) -> None:
         super().__init__('Tornado', system)
-        self.tornado_angle: float = 30.0
-        self.drill_with_open_tornado: bool = False
-        self.drill_between_crops: bool = False
         self.field_friend = system.field_friend
+        self.tornado_angle: float = self.TORNADO_ANGLE
+        self.drill_with_open_tornado: bool = self.DRILL_WITH_OPEN_TORNADO
+        self.drill_between_crops: bool = self.DRILL_BETWEEN_CROPS
 
     async def start_workflow(self) -> None:
         await super().start_workflow()
@@ -102,9 +106,9 @@ class Tornado(WeedingImplement):
 
     def restore_from_dict(self, data: dict[str, Any]) -> None:
         super().restore_from_dict(data)
-        self.drill_with_open_tornado = data.get('drill_with_open_tornado', self.drill_with_open_tornado)
-        self.drill_between_crops = data.get('drill_between_crops', self.drill_between_crops)
-        self.tornado_angle = data.get('tornado_angle', self.tornado_angle)
+        self.drill_with_open_tornado = data.get('drill_with_open_tornado', self.DRILL_WITH_OPEN_TORNADO)
+        self.drill_between_crops = data.get('drill_between_crops', self.DRILL_BETWEEN_CROPS)
+        self.tornado_angle = data.get('tornado_angle', self.TORNADO_ANGLE)
 
     def settings_ui(self):
         super().settings_ui()
@@ -112,7 +116,7 @@ class Tornado(WeedingImplement):
             .props('dense outlined suffix=°') \
             .classes('w-24') \
             .bind_value(self, 'tornado_angle') \
-            .tooltip('Set the angle for the tornado drill')
+            .tooltip(f'Set the angle for the tornado drill (default: {self.TORNADO_ANGLE}°)')
         ui.label().bind_text_from(self, 'tornado_angle', lambda v: f'Tornado diameters: {self.field_friend.tornado_diameters(v)[0]*100:.1f} cm '
                                   f'- {self.field_friend.tornado_diameters(v)[1]*100:.1f} cm')
         # TODO test and reactivate these options

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -91,7 +91,7 @@ class Tornado(WeedingImplement):
         self.next_punch_y_position = closest_crop_position.y
         return closest_crop_world_position.projection()
 
-    def _crops_in_drill_range(self, crop_id: str, crop_position: rosys.geometry.Point, angle: float) -> bool:
+    def _crops_in_drill_range(self, crop_id: str, crop_position: Point, angle: float) -> bool:
         inner_diameter, outer_diameter = self.system.field_friend.tornado_diameters(angle)
         crop_world_position = self.system.robot_locator.pose.transform(crop_position)
         for crop in self.system.plant_provider.crops:

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -37,7 +36,7 @@ class Tornado(WeedingImplement):
             punch_position = self.system.robot_locator.pose.transform(
                 rosys.geometry.Point(x=self.system.field_friend.WORK_X, y=self.next_punch_y_position))
             self.last_punches.append(Point3d.from_point(punch_position))
-            self.log.debug(f'Drilling crop at {punch_position} with angle {self.tornado_angle}°')
+            self.log.debug('Drilling crop at %s with angle %.1f°', punch_position, self.tornado_angle)
             await self.system.puncher.punch(y=self.next_punch_y_position, depth=self.drill_depth, angle=self.tornado_angle, with_open_tornado=self.drill_with_open_tornado)
             # TODO remove weeds from plant_provider
             if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
@@ -85,10 +84,10 @@ class Tornado(WeedingImplement):
 
         relative_x = closest_crop_position.x - self.system.field_friend.WORK_X
         if relative_x < - self.system.field_friend.DRILL_RADIUS:
-            self.log.debug(f'Skipping crop {closest_crop_id} because it is behind the robot')
+            self.log.debug('Skipping crop %s because it is behind the robot', closest_crop_id)
             return None
-        self.log.debug(f'Targeting crop {closest_crop_id} which is {relative_x} away at world: '
-                           f'{closest_crop_world_position}, local: {closest_crop_position}')
+        self.log.debug('Targeting crop %s which is %.2f away at world: %s, local: %s',
+                      closest_crop_id, relative_x, closest_crop_world_position, closest_crop_position)
         self.next_punch_y_position = closest_crop_position.y
         return closest_crop_world_position.projection()
 

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -124,18 +124,32 @@ class Tornado(WeedingImplement):
 
     def settings_ui(self):
         super().settings_ui()
-        ui.number('Tornado angle', format='%.0f', step=1, min=0, max=180, on_change=self.request_backup) \
-            .props('dense outlined suffix=°') \
-            .classes('w-24') \
-            .bind_value(self, 'tornado_angle') \
-            .tooltip(f'Set the angle for the tornado drill (default: {self.TORNADO_ANGLE}°)')
+        with ui.card().props('flat bordered').classes('w-full'):
+            ui.label('Tornado Angle')
+            with ui.grid(columns=2).classes('w-full gap-0'):
+                ui.label('Knife angle:')
+                angle_label = ui.label()
+                ui.label('Inner diameter:')
+                inner_label = ui.label()
+                ui.label('Outer diameter:')
+                outer_label = ui.label()
+
+            def get_angle_label() -> None:
+                angle = self.tornado_angle
+                inner_diameter, outer_diameter = self.field_friend.tornado_diameters(angle)
+                angle_label.set_text(f'{angle}°')
+                inner_label.set_text(f'{inner_diameter*100:.1f} cm')
+                outer_label.set_text(f'{outer_diameter*100:.1f} cm')
+
+            ui.slider(min=0, max=180, step=1, on_change=get_angle_label) \
+                .bind_value(self, 'tornado_angle', forward=lambda v: 180-v, backward=lambda v: abs(v-180)) \
+                .tooltip(f'Set the angle for the tornado drill. Moving to the left will decrease the diameter and moving to the right will increase it. (default: {self.TORNADO_ANGLE}°)')
+
         ui.number('Drill depth', format='%.2f', step=0.01, on_change=self.request_backup) \
             .props('dense outlined suffix=m') \
             .classes('w-24') \
             .bind_value(self, 'drill_depth') \
-            .tooltip(f'Set the depth for the tornado drill. 0 is at ground level and positive values are below ground level (default: {self.DRILL_DEPTH}m)')
-        ui.label().bind_text_from(self, 'tornado_angle', lambda v: f'Tornado diameters: {self.field_friend.tornado_diameters(v)[0]*100:.1f} cm '
-                                  f'- {self.field_friend.tornado_diameters(v)[1]*100:.1f} cm')
+            .tooltip(f'Set the depth for the tornado drill. 0 is at ground level and positive values are below ground level (default: {self.DRILL_DEPTH:.2f}m)')
         ui.checkbox('Skip if no weeds') \
             .bind_value(self, 'skip_if_no_weeds') \
             .tooltip(f'Set the weeding automation to skip if no weeds are found (default: {self.SKIP_IF_NO_WEEDS})')

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -34,7 +34,7 @@ class Tornado(WeedingImplement):
         try:
             # TODO: do we need to set self.next_crop_id = '' on every return?
             punch_position = self.system.robot_locator.pose.transform(
-                rosys.geometry.Point(x=self.system.field_friend.WORK_X, y=self.next_punch_y_position))
+                Point(x=self.system.field_friend.WORK_X, y=self.next_punch_y_position))
             self.last_punches.append(Point3d.from_point(punch_position))
             self.log.debug('Drilling crop at %s with angle %.1f°', punch_position, self.tornado_angle)
             await self.system.puncher.punch(y=self.next_punch_y_position, depth=self.drill_depth, angle=self.tornado_angle, with_open_tornado=self.drill_with_open_tornado)

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -134,6 +134,8 @@ class Tornado(WeedingImplement):
             def get_angle_label() -> None:
                 angle = self.tornado_angle
                 inner_diameter, outer_diameter = self.field_friend.tornado_diameters(angle)
+                if self.drill_with_open_tornado:
+                    outer_diameter = self.field_friend.tornado_diameters(0)[1]
                 angle_label.set_text(f'{angle}°')
                 inner_label.set_text(f'{inner_diameter*100:.1f} cm')
                 outer_label.set_text(f'{outer_diameter*100:.1f} cm')
@@ -141,18 +143,18 @@ class Tornado(WeedingImplement):
             ui.slider(min=0, max=180, step=1, on_change=get_angle_label) \
                 .bind_value(self, 'tornado_angle', forward=lambda v: 180-v, backward=lambda v: abs(v-180)) \
                 .tooltip(f'Set the angle for the tornado drill. Moving to the left will decrease the diameter and moving to the right will increase it. (default: {self.TORNADO_ANGLE}°)')
+            ui.checkbox('Second drill with the biggest diameter', on_change=get_angle_label) \
+                .bind_value(self, 'drill_with_open_tornado') \
+                .tooltip(f'Drill a second time with 0° angle (default: {self.DRILL_WITH_OPEN_TORNADO})')
 
         ui.number('Drill depth', format='%.2f', step=0.01, on_change=self.request_backup) \
             .props('dense outlined suffix=m') \
             .classes('w-24') \
             .bind_value(self, 'drill_depth') \
             .tooltip(f'Set the depth for the tornado drill. 0 is at ground level and positive values are below ground level (default: {self.DRILL_DEPTH:.2f}m)')
-        ui.checkbox('Second drill with open tornado') \
-            .bind_value(self, 'drill_with_open_tornado') \
-            .tooltip(f'Set the weeding automation to drill a second time with open tornado (default: {self.DRILL_WITH_OPEN_TORNADO})')
         ui.checkbox('Skip if no weeds') \
             .bind_value(self, 'skip_if_no_weeds') \
-            .tooltip(f'Set the weeding automation to skip if no weeds are found (default: {self.SKIP_IF_NO_WEEDS})')
+            .tooltip(f'Skip crops with no weeds in their vicinity (default: {self.SKIP_IF_NO_WEEDS})')
         # ui.checkbox('Drill between crops') \
         #     .bind_value(self, 'drill_between_crops') \
         #     .tooltip('Set the weeding automation to drill between crops')

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -58,7 +58,6 @@ class Tornado(WeedingImplement):
         super()._has_plants_to_handle()
         if len(self.crops_to_handle) == 0:
             return False
-        self.weeds_to_handle = {}
         return True
 
     @track

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -63,7 +63,7 @@ class Tornado(WeedingImplement):
         return True
 
     @track
-    async def get_move_target(self) -> Point | None:
+    async def get_move_target(self) -> Point | None: # pylint: disable=too-many-return-statements
         """Return the target position to drive to."""
         self._has_plants_to_handle()
         if len(self.crops_to_handle) == 0:

--- a/field_friend/automations/implements/tornado.py
+++ b/field_friend/automations/implements/tornado.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 class Tornado(WeedingImplement):
     DRILL_BETWEEN_CROPS = False
+    DRILL_DEPTH = 0.0
     DRILL_WITH_OPEN_TORNADO = False
     SKIP_IF_NO_WEEDS = False
     TORNADO_ANGLE = 30.0
@@ -24,6 +25,7 @@ class Tornado(WeedingImplement):
         super().__init__('Tornado', system)
         self.field_friend = system.field_friend
         self.drill_between_crops: bool = self.DRILL_BETWEEN_CROPS
+        self.drill_depth: float = self.DRILL_DEPTH
         self.drill_with_open_tornado: bool = self.DRILL_WITH_OPEN_TORNADO
         self.skip_if_no_weeds: bool = self.SKIP_IF_NO_WEEDS
         self.tornado_angle: float = self.TORNADO_ANGLE
@@ -39,7 +41,7 @@ class Tornado(WeedingImplement):
             open_drill = False
             if self.drill_with_open_tornado:
                 open_drill = True
-            await self.system.puncher.punch(y=self.next_punch_y_position, angle=self.tornado_angle, with_open_tornado=open_drill)
+            await self.system.puncher.punch(y=self.next_punch_y_position, depth=self.drill_depth, angle=self.tornado_angle, with_open_tornado=open_drill)
             # TODO remove weeds from plant_provider
             if isinstance(self.system.detector, rosys.vision.DetectorSimulation):
                 # remove the simulated weeds
@@ -106,6 +108,7 @@ class Tornado(WeedingImplement):
     def backup_to_dict(self) -> dict[str, Any]:
         return super().backup_to_dict() | {
             'drill_between_crops': self.drill_between_crops,
+            'drill_depth': self.drill_depth,
             'drill_with_open_tornado': self.drill_with_open_tornado,
             'skip_if_no_weeds': self.skip_if_no_weeds,
             'tornado_angle': self.tornado_angle,
@@ -114,6 +117,7 @@ class Tornado(WeedingImplement):
     def restore_from_dict(self, data: dict[str, Any]) -> None:
         super().restore_from_dict(data)
         self.drill_between_crops = data.get('drill_between_crops', self.DRILL_BETWEEN_CROPS)
+        self.drill_depth = data.get('drill_depth', self.DRILL_DEPTH)
         self.drill_with_open_tornado = data.get('drill_with_open_tornado', self.DRILL_WITH_OPEN_TORNADO)
         self.skip_if_no_weeds = data.get('skip_if_no_weeds', self.SKIP_IF_NO_WEEDS)
         self.tornado_angle = data.get('tornado_angle', self.TORNADO_ANGLE)
@@ -125,6 +129,11 @@ class Tornado(WeedingImplement):
             .classes('w-24') \
             .bind_value(self, 'tornado_angle') \
             .tooltip(f'Set the angle for the tornado drill (default: {self.TORNADO_ANGLE}°)')
+        ui.number('Drill depth', format='%.2f', step=0.01, on_change=self.request_backup) \
+            .props('dense outlined suffix=m') \
+            .classes('w-24') \
+            .bind_value(self, 'drill_depth') \
+            .tooltip(f'Set the depth for the tornado drill. 0 is at ground level and positive values are below ground level (default: {self.DRILL_DEPTH}m)')
         ui.label().bind_text_from(self, 'tornado_angle', lambda v: f'Tornado diameters: {self.field_friend.tornado_diameters(v)[0]*100:.1f} cm '
                                   f'- {self.field_friend.tornado_diameters(v)[1]*100:.1f} cm')
         ui.checkbox('Skip if no weeds') \

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -150,6 +150,7 @@ class Puncher:
         :param turns: number of turns around the crop
         :param with_open_drill: will drill again with open drill after the first drill
         """
+        assert 0 <= angle <= 180, f'angle must be between 0 and 180, got {angle}'
         self.log.debug('Drilling with tornado at %.1f°...', angle)
         if not isinstance(self.field_friend.z_axis, Tornado):
             raise PuncherException('tornado drill is only available for tornado axis')
@@ -166,7 +167,9 @@ class Puncher:
             if depth != 0.0 and not self.is_demo:
                 await self.field_friend.z_axis.move_to(min(self.field_friend.z_axis.position_z + depth, 0))
 
-            await self.field_friend.z_axis.turn_knifes_to(angle)
+            # NOTE: to not harm the plant, we need to turn the knifes to the opposite side (90° -> 270°, 170° -> 190°)
+            corrected_angle = (360 - angle) % 360
+            await self.field_friend.z_axis.turn_knifes_to(corrected_angle)
             await rosys.sleep(0.2)
             await self.field_friend.z_axis.turn_by(turns)
             await rosys.sleep(0.2)

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -151,7 +151,9 @@ class Puncher:
         :param with_open_drill: will drill again with open drill after the first drill
         """
         assert 0 <= angle <= 180, f'angle must be between 0 and 180, got {angle}'
-        self.log.debug('Drilling with tornado at %.1f°...', angle)
+        # NOTE: to not harm the plant, we need to turn the knifes to the opposite side (90° -> 270°, 170° -> 190°)
+        corrected_angle = (360 - angle) % 360
+        self.log.debug('Drilling with tornado at %.1f° (corrected from %.1f°)', corrected_angle, angle)
         if not isinstance(self.field_friend.z_axis, Tornado):
             raise PuncherException('tornado drill is only available for tornado axis')
         try:
@@ -167,8 +169,6 @@ class Puncher:
             if depth != 0.0 and not self.is_demo:
                 await self.field_friend.z_axis.move_to(min(self.field_friend.z_axis.position_z + depth, 0))
 
-            # NOTE: to not harm the plant, we need to turn the knifes to the opposite side (90° -> 270°, 170° -> 190°)
-            corrected_angle = (360 - angle) % 360
             await self.field_friend.z_axis.turn_knifes_to(corrected_angle)
             await rosys.sleep(0.2)
             await self.field_friend.z_axis.turn_by(turns)

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -125,7 +125,8 @@ class Puncher:
             if isinstance(self.field_friend.z_axis, Axis):
                 if self.field_friend.z_axis.position != 0:
                     await self.field_friend.z_axis.return_to_reference()
-            y = (self.field_friend.y_axis.min_position + 0.002) if self.field_friend.y_axis.position <= 0 else (self.field_friend.y_axis.max_position - 0.002)
+            y = (self.field_friend.y_axis.min_position + 0.002) if self.field_friend.y_axis.position <= 0 \
+                else (self.field_friend.y_axis.max_position - 0.002)
             await self.field_friend.y_axis.move_to(y, speed=self.field_friend.y_axis.max_speed)
         await self.field_friend.y_axis.stop()
 

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -170,7 +170,7 @@ class Puncher:
             await self.field_friend.z_axis.turn_by(turns)
             await rosys.sleep(0.2)
 
-            if with_open_drill:
+            if with_open_drill and angle > 0:
                 self.log.debug('Drilling again with open drill...')
                 await self.field_friend.z_axis.turn_knifes_to(0)
                 await rosys.sleep(0.2)

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -140,7 +140,15 @@ class Puncher:
         await self.field_friend.y_axis.stop()
 
     @track
-    async def tornado_drill(self, angle: float = 180, turns: float = 2, with_open_drill=False) -> None:
+    async def tornado_drill(self, angle: float = 180, depth: float = 0.0, turns: float = 2.0, with_open_drill=False) -> None:
+        """
+        Drills a crop with the tornado implement.
+
+        :param angle: angle of the knifes
+        :param depth: working depth. 0 is at ground level and positive values are below ground level
+        :param turns: number of turns around the crop
+        :param with_open_drill: will drill again with open drill after the first drill
+        """
         self.log.debug(f'Drilling with tornado at {angle}°...')
         if not isinstance(self.field_friend.z_axis, Tornado):
             raise PuncherException('tornado drill is only available for tornado axis')
@@ -152,6 +160,10 @@ class Puncher:
                     raise PuncherException('homing failed')
                 await rosys.sleep(0.5)
             await self.field_friend.z_axis.move_down_until_reference(min_position=-0.058 if self.is_demo else None)
+            if depth != 0.0 and not self.is_demo:
+                # TODO: are 2 seconds needed here?
+                await rosys.sleep(2.0)
+                await self.field_friend.z_axis.move_to(min(self.field_friend.z_axis.position_z + depth, 0))
 
             await self.field_friend.z_axis.turn_knifes_to(angle)
             await rosys.sleep(0.2)

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -48,10 +48,10 @@ class Puncher:
         if self.field_friend.y_axis is None or self.field_friend.z_axis is None:
             rosys.notify('no y or z axis', 'negative')
             return
-        self.log.info(f'Driving to punch at {local_target_x:.2f}...')
+        self.log.info('Driving to punch at %.2f...', local_target_x)
         work_x = self.field_friend.WORK_X
         if local_target_x < work_x:
-            self.log.info(f'Target: {local_target_x} is behind')
+            self.log.info('Target: %.2f is behind', local_target_x)
         axis_distance = local_target_x - work_x
         local_target = Point(x=axis_distance, y=0)
         world_target = self.driver.prediction.transform(local_target)
@@ -68,7 +68,7 @@ class Puncher:
                     ) -> None:
         y += self.field_friend.WORK_Y
         y = round(y, 5)
-        self.log.debug(f'Punching at {y} with depth {depth}...')
+        self.log.debug('Punching at %.5f with depth %.2f...', y, depth)
         rest_position = 'reference'
         if self.field_friend.y_axis is None or self.field_friend.z_axis is None:
             rosys.notify('no y or z axis', 'negative')
@@ -105,7 +105,7 @@ class Puncher:
                     rest_position = f'custom position {target}'
                 else:
                     await self.field_friend.z_axis.return_to_reference()
-            self.log.debug(f'punched at {y:.2f} with depth {depth}, now back to rest position "{rest_position}"')
+            self.log.debug('punched at %.2f with depth %.2f, now back to rest position "%s"', y, depth, rest_position)
         except Exception as e:
             raise PuncherException('punching failed') from e
         finally:
@@ -149,7 +149,7 @@ class Puncher:
         :param turns: number of turns around the crop
         :param with_open_drill: will drill again with open drill after the first drill
         """
-        self.log.debug(f'Drilling with tornado at {angle}°...')
+        self.log.debug('Drilling with tornado at %.1f°...', angle)
         if not isinstance(self.field_friend.z_axis, Tornado):
             raise PuncherException('tornado drill is only available for tornado axis')
         try:

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -160,9 +160,9 @@ class Puncher:
                     raise PuncherException('homing failed')
                 await rosys.sleep(0.5)
             await self.field_friend.z_axis.move_down_until_reference(min_position=-0.058 if self.is_demo else None)
+            # TODO: find out why this sleep is needed
+            await rosys.sleep(2.0)
             if depth != 0.0 and not self.is_demo:
-                # TODO: are 2 seconds needed here?
-                await rosys.sleep(2.0)
                 await self.field_friend.z_axis.move_to(min(self.field_friend.z_axis.position_z + depth, 0))
 
             await self.field_friend.z_axis.turn_knifes_to(angle)

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -154,21 +154,21 @@ class Puncher:
             await self.field_friend.z_axis.move_down_until_reference(min_position=-0.058 if self.is_demo else None)
 
             await self.field_friend.z_axis.turn_knifes_to(angle)
-            await rosys.sleep(2)
+            await rosys.sleep(0.2)
             await self.field_friend.z_axis.turn_by(turns)
-            await rosys.sleep(2)
+            await rosys.sleep(0.2)
 
             if with_open_drill:
                 self.log.debug('Drilling again with open drill...')
                 await self.field_friend.z_axis.turn_knifes_to(0)
-                await rosys.sleep(2)
+                await rosys.sleep(0.2)
                 await self.field_friend.z_axis.turn_by(turns)
-                await rosys.sleep(2)
+                await rosys.sleep(0.2)
 
             await self.field_friend.z_axis.return_to_reference()
-            await rosys.sleep(0.5)
+            await rosys.sleep(0.2)
             await self.field_friend.z_axis.turn_knifes_to(0)
-            await rosys.sleep(0.5)
+            await rosys.sleep(0.2)
         except Exception as e:
             raise PuncherException(f'tornado drill failed because of: {e}') from e
         finally:

--- a/field_friend/automations/puncher.py
+++ b/field_friend/automations/puncher.py
@@ -94,7 +94,7 @@ class Puncher:
                 assert isinstance(self.field_friend.y_axis, Axis)
                 await rosys.run.retry(lambda y=y: self.field_friend.y_axis.move_to(y),  # type: ignore
                                       on_failed=self.field_friend.y_axis.recover)
-                await self.tornado_drill(angle=angle, turns=turns, with_open_drill=with_open_tornado)
+                await self.tornado_drill(angle=angle, depth=depth, turns=turns, with_open_drill=with_open_tornado)
 
             elif isinstance(self.field_friend.z_axis, Axis):
                 await self.field_friend.y_axis.move_to(y)

--- a/field_friend/hardware/tornado.py
+++ b/field_friend/hardware/tornado.py
@@ -200,7 +200,7 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
         try:
             if min_position is None:
                 min_position = self.config.min_position
-            self.log.info(f'moving z axis down to {min_position}')
+            self.log.debug(f'moving z axis down to {min_position}')
             await self.robot_brain.send(
                 f'{self.config.name}_knife_stop_enabled = true;'
                 f'{self.config.name}_knife_ground_enabled = true;'
@@ -212,7 +212,7 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
             await rosys.sleep(0.5)
             while self.ref_knife_ground and not self.ref_knife_stop:
                 if min_position - 0.005 <= self.position_z <= min_position + 0.005:
-                    self.log.info('minimum position reached')
+                    self.log.debug('minimum position reached')
                     break
                 await self.robot_brain.send(
                     f'{self.config.name}_z.position({min_position}, {self.config.speed_limit}, 0);'
@@ -221,7 +221,7 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
             if self.ref_knife_stop:
                 raise Exception('Error while moving z axis down: Ref knifes stop triggered')
             if not self.ref_knife_ground:
-                self.log.info('Ref ground not triggered: Bottom ground reached')
+                self.log.debug('Ref ground not triggered: Bottom ground reached')
         except Exception as e:
             self.log.error(f'error while moving z axis down: {e}')
             self.is_referenced = False
@@ -229,8 +229,7 @@ class TornadoHardware(Tornado, rosys.hardware.ModuleHardware):
             self.turn_is_referenced = False
             raise Exception(e) from e
         finally:
-            # await rosys.sleep(1.5)
-            self.log.info('finalizing moving z axis down')
+            self.log.debug('finalizing moving z axis down')
             await self.robot_brain.send(
                 f'{self.config.name}_knife_stop_enabled = false;'
                 f'{self.config.name}_knife_ground_enabled = false;'

--- a/tests/test_weeding.py
+++ b/tests/test_weeding.py
@@ -189,14 +189,19 @@ async def test_tornado_removes_weeds_around_crop(system: System, detector: rosys
 @pytest.mark.parametrize('system', ['u4'], indirect=True)
 async def test_tornado_skips_crop_if_no_weeds(system: System, detector: rosys.vision.DetectorSimulation):
     detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',
-                                                                   position=rosys.geometry.Point3d(x=0.5, y=0.0, z=0)))
+                                                                   position=rosys.geometry.Point3d(x=0.2, y=0.0, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=0.2, y=0.05, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',
+                                                                   position=rosys.geometry.Point3d(x=0.6, y=0.0, z=0)))
     system.current_implement = system.implements['Tornado']
     system.current_navigation = system.straight_line_navigation
     system.current_implement.skip_if_no_weeds = True
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
     await forward(until=lambda: system.automator.is_stopped)
-    assert len(system.current_implement.last_punches) == 0
+    assert len(system.current_implement.last_punches) == 1
+    assert len(detector.simulated_objects) == 2
 
 
 @pytest.mark.skip(reason='Tornado does not yet remove weeds between crops')

--- a/tests/test_weeding.py
+++ b/tests/test_weeding.py
@@ -187,6 +187,33 @@ async def test_tornado_removes_weeds_around_crop(system: System, detector: rosys
 
 
 @pytest.mark.parametrize('system', ['u4'], indirect=True)
+async def test_tornado_drill_with_open_tornado(system: System, detector: rosys.vision.DetectorSimulation):
+    MIN_RADIUS = 0.069 / 2
+    MAX_RADIUS = 0.165 / 2
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',
+                                                                   position=rosys.geometry.Point3d(x=0.4, y=0.0, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=0.4, y=MIN_RADIUS - 0.01, z=0)))
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
+                                                                   position=rosys.geometry.Point3d(x=0.4, y=MAX_RADIUS + 0.01, z=0)))
+    targets = [
+        rosys.vision.SimulatedObject(category_name='weed', position=rosys.geometry.Point3d(x=0.4, y=MIN_RADIUS + 0.01, z=0)),
+        rosys.vision.SimulatedObject(category_name='weed',  position=rosys.geometry.Point3d(x=0.4, y=MAX_RADIUS - 0.01, z=0))
+    ]
+    detector.simulated_objects.extend(targets)
+    system.current_implement = system.implements['Tornado']
+    system.current_navigation = system.straight_line_navigation
+    system.current_implement.tornado_angle = 180
+    system.current_implement.drill_with_open_tornado = True
+    system.automator.start()
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.automator.is_stopped)
+    assert len(detector.simulated_objects) == 3
+    for target in targets:
+        assert target not in detector.simulated_objects, f'target {target.position} should be removed'
+
+
+@pytest.mark.parametrize('system', ['u4'], indirect=True)
 async def test_tornado_skips_crop_if_no_weeds(system: System, detector: rosys.vision.DetectorSimulation):
     detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',
                                                                    position=rosys.geometry.Point3d(x=0.2, y=0.0, z=0)))

--- a/tests/test_weeding.py
+++ b/tests/test_weeding.py
@@ -186,6 +186,19 @@ async def test_tornado_removes_weeds_around_crop(system: System, detector: rosys
     assert detector.simulated_objects[0].category_name == 'sugar_beet'
 
 
+@pytest.mark.parametrize('system', ['u4'], indirect=True)
+async def test_tornado_skips_crop_if_no_weeds(system: System, detector: rosys.vision.DetectorSimulation):
+    detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',
+                                                                   position=rosys.geometry.Point3d(x=0.5, y=0.0, z=0)))
+    system.current_implement = system.implements['Tornado']
+    system.current_navigation = system.straight_line_navigation
+    system.current_implement.skip_if_no_weeds = True
+    system.automator.start()
+    await forward(until=lambda: system.automator.is_running)
+    await forward(until=lambda: system.automator.is_stopped)
+    assert len(system.current_implement.last_punches) == 0
+
+
 @pytest.mark.skip(reason='Tornado does not yet remove weeds between crops')
 @pytest.mark.parametrize('system', ['u4'], indirect=True)
 async def test_tornado_removes_weeds_between_crops(system: System, detector: rosys.vision.DetectorSimulation):


### PR DESCRIPTION
### Motivation

This PR implements multiple improvements developed by @SeaTechRC to make the Tornado implement faster and less harmful for the crops.

### Implementation

- Decrease waiting times between move commands
- Skip of crops when no weeds are in the vicinity
- Variable drill depth to avoid damage to the roots of the crops when the soil is too loose
- Add a more intuitive slider for the tornado angle
- Calculate a corrected tornado angle: When turning to its angle, at the start already turn away from the plant to not harm them afterwards when returning to 0°
    - 0° is still 0°
    - 180° is still 180°
    - 90° becomes 270°
    - 170° becomes 190°
- Minor cleanups

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).