### PR TITLE
Support points

### DIFF
--- a/field_friend/interface/components/field_object.py
+++ b/field_friend/interface/components/field_object.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from nicegui.elements.scene_objects import Box, Curve, Cylinder, Group
-from rosys.geometry import Spline
+from rosys.geometry import Point, Spline
 
 from ...automations import Field, FieldProvider
 
@@ -65,10 +65,10 @@ class FieldObject(Group):
                 end = outline[(i + 1) % len(outline)]  # Loop back to the first point
                 self.create_fence(start, end)
 
-            for row in active_field.rows:
+            for row_index, row in enumerate(active_field.rows):
                 if len(row.points) == 1:
                     continue
-                row_points = [point.to_local() for point in row.points]
+                row_points: list[Point] = [point.to_local() for point in row.points]
                 for i, (point1, point2) in enumerate(pairwise(row_points)):
                     spline = Spline.from_points(point1, point2)
                     Curve(
@@ -77,7 +77,15 @@ class FieldObject(Group):
                         [spline.control2.x, spline.control2.y, 0],
                         [spline.end.x, spline.end.y, 0],
                     ).material('#6c541e').with_name(f'row_{row.id}_{i}')
-                self.scene.text(row.name.replace('row_', ''), style='font-size: 0.6em;') \
+                bed_row_index = int(row.name.replace('row_', '')) % active_field.row_count
+                self.scene.text(bed_row_index, style='font-size: 0.6em;') \
                     .move(x=row_points[0].x, y=row_points[0].y, z=0.01).with_name(f'{row.name}_label_start')
-                self.scene.text(row.name.replace('row_', ''), style='font-size: 0.6em;') \
+                self.scene.text(bed_row_index, style='font-size: 0.6em;') \
                     .move(x=row_points[-1].x, y=row_points[-1].y, z=0.01).with_name(f'{row.name}_label_end')
+
+                if row_index % active_field.row_count == 0:
+                    row_direction = row_points[0].direction(row_points[-1])
+                    bed_point = row_points[0].polar(-0.5, row_direction)
+                    bed_index = f'{int(row_index / active_field.row_count)}'
+                    self.scene.text('Bed ' + bed_index, style='font-size: 0.6em;') \
+                        .move(x=bed_point.x, y=bed_point.y, z=0.01).with_name(f'bed_{bed_index}_label')


### PR DESCRIPTION
### Motivation

Users had issues using the support point dialog for field rows, deciding which row is the current one.

### Implementation

- Display Bed IDs in the 3D view
- Display the row IDs per bed, instead of the global ID in the 3D view
- Instead of `ui.number` use `ui.select` to select the current row
- Fix the warning if no RTK is available
- Disable the next button if no RTK is available
- Allow to update the current position in the confirmation screen

### Progress

- [ ] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [ ] Tests with a real hardware have been successful (or are not necessary).
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
