### PR TITLE
Fix bed name removal from `FieldObject`

### DIFF
--- a/field_friend/interface/components/field_object.py
+++ b/field_friend/interface/components/field_object.py
@@ -54,7 +54,7 @@ class FieldObject(Group):
     def update(self, active_field: Field | None) -> None:
         # TODO: now we have empty keys in our objects dict. Is this intended?
         for obj in list(self.scene.objects.values()):
-            if obj.name and obj.name.startswith(('field_', 'row_')):
+            if obj.name and obj.name.startswith(('field_', 'row_', 'bed_')):
                 obj.delete()
 
         if active_field is None:


### PR DESCRIPTION
### Motivation

In https://github.com/zauberzeug/field_friend/pull/343 I introduced labels for the bed indices in the 3D scene. I forgot to remove them, when the field is deselected.

### Implementation

Check for all objects beginning with 'bed_', the same as for rows and fields.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
