### PR TITLE
Ensure environment variables are loaded from the .env file

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,9 @@ from field_friend.system import System
 logger = log_configuration.configure()
 app.add_static_files('/assets', 'assets')
 
+if os.environ.get('ROBOT_ID'):
+    logging.warning(f'The ROBOT_ID environment variable is set to {os.environ.get("ROBOT_ID")} '
+                    'and takes precedence over anything in the .env file.')
 
 load_dotenv('.env')
 

--- a/main.py
+++ b/main.py
@@ -13,11 +13,7 @@ from field_friend.system import System
 logger = log_configuration.configure()
 app.add_static_files('/assets', 'assets')
 
-if os.environ.get('ROBOT_ID'):
-    logging.warning(f'The ROBOT_ID environment variable is set to {os.environ.get("ROBOT_ID")} '
-                    'and takes precedence over anything in the .env file.')
-
-load_dotenv('.env')
+load_dotenv('.env', override=True)
 
 
 def startup() -> None:


### PR DESCRIPTION
### Motivation

I accidentally had set the `ROBOT_ID` in my environment and wondered why my changes to `.env` where not applied.

### Implementation

`load_dotenv` has a `override` parameter, that ignores values from the current environment.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
