### PR TITLE
Formatting and cosmetical changes for the navigation code

### DIFF
--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -120,8 +120,8 @@ class FieldNavigation(StraightLineNavigation):
         if self.force_first_row_start:
             self.row_index = 0
         else:
-            row = min(self.rows_to_work_on, key=lambda r: r.line_segment().line.foot_point(
-                self.robot_locator.pose.point).distance(self.robot_locator.pose.point))
+            row = min(self.rows_to_work_on,
+                      key=lambda r: r.line_segment().line.foot_point(self.robot_locator.pose.point).distance(self.robot_locator.pose.point))
             self.log.debug(f'Nearest row is {row.name}')
             if row not in self.rows_to_work_on:
                 rosys.notify('Please place the robot in front of a selected bed\'s row', 'negative')

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -123,9 +123,6 @@ class FieldNavigation(StraightLineNavigation):
             row = min(self.rows_to_work_on,
                       key=lambda r: r.line_segment().line.foot_point(self.robot_locator.pose.point).distance(self.robot_locator.pose.point))
             self.log.debug(f'Nearest row is {row.name}')
-            if row not in self.rows_to_work_on:
-                rosys.notify('Please place the robot in front of a selected bed\'s row', 'negative')
-                return None
             self.row_index = self.rows_to_work_on.index(row)
         return self.rows_to_work_on[self.row_index]
 

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -49,7 +49,7 @@ class StraightLineNavigation(Navigation):
 
     def _should_finish(self) -> bool:
         end_pose = Pose(x=self.target.x, y=self.target.y, yaw=self.origin.direction(self.target), time=0)
-        return end_pose.relative_point(self.robot_locator.pose.point).x > 0
+        return end_pose.relative_point(self.robot_locator.pose.point).x > -0.0001
 
     def create_simulation(self):
         assert isinstance(self.detector, rosys.vision.DetectorSimulation)

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -56,14 +56,12 @@ class StraightLineNavigation(Navigation):
         crop_distance = 0.2
         start_point = self.robot_locator.pose.transform(Point(x=0.1, y=0))
         for i in range(0, round(self.length / crop_distance)):
-            p = start_point.polar(crop_distance*i,
-                                                    self.robot_locator.pose.yaw) \
+            p = start_point.polar(crop_distance*i, self.robot_locator.pose.yaw) \
                 .polar(randint(-2, 2)*0.01, self.robot_locator.pose.yaw+np.pi/2)
             self.detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',
                                                                                 position=Point3d(x=p.x, y=p.y, z=0)))
             for _ in range(1, 7):
-                p = start_point.polar(0.20*i+randint(-5, 5)*0.01,
-                                                        self.robot_locator.pose.yaw) \
+                p = start_point.polar(0.20*i+randint(-5, 5)*0.01, self.robot_locator.pose.yaw) \
                     .polar(randint(-15, 15)*0.01, self.robot_locator.pose.yaw + np.pi/2)
                 self.detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
                                                                                     position=Point3d(x=p.x, y=p.y, z=0)))

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -49,7 +49,7 @@ class StraightLineNavigation(Navigation):
 
     def _should_finish(self) -> bool:
         end_pose = Pose(x=self.target.x, y=self.target.y, yaw=self.origin.direction(self.target), time=0)
-        return end_pose.relative_point(self.robot_locator.pose.point).x > -0.0001
+        return end_pose.relative_point(self.robot_locator.pose.point).x > 0
 
     def create_simulation(self):
         assert isinstance(self.detector, rosys.vision.DetectorSimulation)

--- a/tests/test_field_provider.py
+++ b/tests/test_field_provider.py
@@ -27,7 +27,8 @@ def test_loading_from_persistence(system: System):
 
 
 def test_loading_from_persistence_with_errors(system: System):
-    system.field_provider.restore_from_dict(json.loads(Path('tests/old_field_provider_persistence_with_errors.json').read_text()))
+    data = json.loads(Path('tests/old_field_provider_persistence_with_errors.json').read_text())
+    system.field_provider.restore_from_dict(data)
     assert len(system.field_provider.fields) == 1
     field = system.field_provider.fields[0]
     # should set outline_buffer_width to default value because it is missing in the persistence data

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -70,7 +70,8 @@ async def test_driving_towards_target(system: System, target: rosys.geometry.Poi
     max_turn_angle = np.deg2rad(max_turn_angle)
     assert isinstance(system.current_navigation, StraightLineNavigation)
     system.current_navigation.linear_speed_limit = 0.1
-    system.automator.start(system.current_navigation.drive_towards_target(target, target_heading=0.0, max_turn_angle=max_turn_angle))
+    system.automator.start(system.current_navigation.drive_towards_target(
+        target, target_heading=0.0, max_turn_angle=max_turn_angle))
     await forward(until=lambda: system.automator.is_running)
     await forward(until=lambda: system.automator.is_stopped, timeout=300)
     assert system.robot_locator.pose.point.x == pytest.approx(end_pose.x, abs=0.005)
@@ -150,6 +151,7 @@ async def test_deceleration_different_speeds(system_with_acceleration: System, l
     await forward(until=lambda: system.automator.is_running)
     await forward(until=lambda: system.automator.is_stopped)
     assert system.robot_locator.pose.point.x == pytest.approx(0.005, abs=0.0005)
+
 
 @pytest.mark.parametrize('heading_degrees', (-180, -90, 0, 90, 180, 360))
 async def test_driving_turn_to_yaw(system: System, heading_degrees: float):
@@ -262,6 +264,7 @@ async def test_follow_crops_adjust(system: System, detector: rosys.vision.Detect
     assert system.robot_locator.pose.point.x == pytest.approx(9.93, abs=0.1)
     assert system.robot_locator.pose.point.y == pytest.approx(-1.24, abs=0.1)
     assert system.robot_locator.pose.yaw_deg == pytest.approx(-7.2, abs=1.0)
+
 
 @pytest.mark.skip(reason='Follow crops navigation will be reworked')
 async def test_follow_crops_curve(system: System, detector: rosys.vision.DetectorSimulation):

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -11,7 +11,7 @@ from rosys.testing import assert_point, forward
 from field_friend import System
 from field_friend.automations import Field
 from field_friend.automations.implements import Implement, Recorder, Tornado, WeedingImplement
-from field_friend.automations.navigation import StraightLineNavigation
+from field_friend.automations.navigation import Navigation, StraightLineNavigation
 from field_friend.automations.navigation.field_navigation import State as FieldNavigationState
 from field_friend.hardware.double_wheels import WheelsSimulationWithAcceleration
 
@@ -123,6 +123,7 @@ async def test_driving_to_exact_positions(system: System):
         assert system.robot_locator.pose.point.x == pytest.approx(stopper.current_target_position.x, abs=0.001)
         assert system.robot_locator.pose.point.y == pytest.approx(stopper.current_target_position.y, abs=0.001)
         await forward(0.1)  # give robot time to update position
+    system.current_navigation.linear_speed_limit = Navigation.LINEAR_SPEED_LIMIT
     await forward(until=lambda: system.automator.is_stopped)
     assert system.robot_locator.pose.x == pytest.approx(system.current_navigation.length, abs=0.001)
 

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -51,13 +51,15 @@ async def test_straight_line_with_high_angles(system: System):
     await forward(until=lambda: abs(rosys.helpers.angle(system.robot_locator.pose.yaw, target_yaw)) < np.deg2rad(0.1))
     await system.driver.wheels.stop()
     assert isinstance(system.current_navigation, StraightLineNavigation)
+    assert isinstance(system.current_navigation.implement, Recorder)
     system.current_navigation.length = 1.0
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
-    await forward(until=lambda: system.automator.is_stopped)
+    await forward(until=lambda: system.automator.is_stopped, timeout=24)
     assert system.robot_locator.pose.point.x == pytest.approx(-0.985, abs=0.1)
     assert system.robot_locator.pose.point.y == pytest.approx(-0.174, abs=0.1)
     assert system.robot_locator.pose.yaw_deg == pytest.approx(predicted_yaw, abs=5)
+
 
 @pytest.mark.parametrize('target, end_pose, max_turn_angle', [
     (rosys.geometry.Point(x=1.0, y=0.0), rosys.geometry.Pose(x=1.0, y=0.0, yaw=0.0), 1.0),


### PR DESCRIPTION
### Motivation

Locally executed navigation tests produce two failures:

```
FAILED tests/test_navigation.py::test_straight_line_with_high_angles - TimeoutError: condition took more than 100 s
FAILED tests/test_navigation.py::test_driving_to_exact_positions - TimeoutError: condition took more than 100 s
```

### Implementation

I fixed some formatting, added a epsilon to the StraightLineNavigation "should_stop" and switched back to normal driving speed for the exact positions test.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
