### PR TITLE
Reduce soil damage with a three-point row change

### DIFF
--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -7,7 +7,7 @@ import numpy as np
 import rosys
 from nicegui import ui
 from rosys.analysis import track
-from rosys.geometry import Point
+from rosys.geometry import Point, Point3d, Pose
 
 from ..field import Field, Row
 from ..implements.implement import Implement
@@ -361,7 +361,7 @@ class FieldNavigation(StraightLineNavigation):
                     p.y += 0.20
                 else:
                     p.y += randint(-5, 5) * 0.01
-                p3d = rosys.geometry.Point3d(x=p.x, y=p.y, z=0)
+                p3d = Point3d(x=p.x, y=p.y, z=0)
                 plant = rosys.vision.SimulatedObject(category_name=crop, position=p3d)
                 self.detector.simulated_objects.append(plant)
 
@@ -369,4 +369,4 @@ class FieldNavigation(StraightLineNavigation):
                     p = self.start_point.polar(crop_distance * (i+1) + randint(-5, 5) * 0.01, self.start_point.direction(self.end_point)) \
                         .polar(randint(-15, 15)*0.01, self.robot_locator.pose.yaw + np.pi/2)
                     self.detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
-                                                                                        position=rosys.geometry.Point3d(x=p.x, y=p.y, z=0)))
+                                                                                        position=Point3d(x=p.x, y=p.y, z=0)))

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -224,8 +224,8 @@ class FieldNavigation(StraightLineNavigation):
     async def _run_follow_row(self) -> State:
         assert self.end_point is not None
         assert self.start_point is not None
-        end_pose = rosys.geometry.Pose(x=self.end_point.x, y=self.end_point.y,
-                                       yaw=self.start_point.direction(self.end_point), time=0)
+        end_yaw = self.start_point.direction(self.end_point)
+        end_pose = Pose(x=self.end_point.x, y=self.end_point.y, yaw=end_yaw)
         distance_from_end = end_pose.relative_point(self.robot_locator.pose.point).x
         if distance_from_end > 0:
             await self.driver.wheels.stop()

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -298,7 +298,7 @@ class FieldNavigation(StraightLineNavigation):
 
     def _set_cultivated_crop(self) -> None:
         if not isinstance(self.implement, WeedingImplement):
-            self.log.warning('Implement is not a weeding implement')
+            self.log.debug('Implement is not a weeding implement. Cannot set cultivated crop')
             return
         if self.current_row is None:
             self.log.warning('No current row')
@@ -319,7 +319,7 @@ class FieldNavigation(StraightLineNavigation):
 
     def _is_start_allowed(self, start_point: Point, end_point: Point, robot_in_working_area: bool) -> bool:
         if not robot_in_working_area:
-            self.log.warning('Robot is not in working area')
+            self.log.debug('Robot is not in working area, will approach start row')
             return True
         if self.current_row is None:
             self.log.warning('No current row')

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -195,7 +195,7 @@ class Navigation(rosys.persistence.Persistable):
         pass
 
     def settings_ui(self) -> None:
-        ui.number('Linear Speed', step=0.01, min=0.01, max=1.0, format='%.2f', on_change=self.request_backup) \
+        ui.number('Linear Speed', step=0.01, min=0.01, max=1.0, format='%.2f', suffix='m/s', on_change=self.request_backup) \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'linear_speed_limit') \

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -68,7 +68,7 @@ class StraightLineNavigation(Navigation):
 
     def settings_ui(self) -> None:
         super().settings_ui()
-        ui.number('Length', step=0.5, min=0.05, format='%.1f', on_change=self.request_backup) \
+        ui.number('Length', step=0.5, min=0.05, format='%.1f', suffix='m', on_change=self.request_backup) \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'length') \

--- a/field_friend/automations/navigation/straight_line_navigation.py
+++ b/field_friend/automations/navigation/straight_line_navigation.py
@@ -56,14 +56,12 @@ class StraightLineNavigation(Navigation):
         crop_distance = 0.2
         start_point = self.robot_locator.pose.transform(Point(x=0.1, y=0))
         for i in range(0, round(self.length / crop_distance)):
-            p = start_point.polar(crop_distance*i,
-                                                    self.robot_locator.pose.yaw) \
+            p = start_point.polar(crop_distance*i, self.robot_locator.pose.yaw) \
                 .polar(randint(-2, 2)*0.01, self.robot_locator.pose.yaw+np.pi/2)
             self.detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='sugar_beet',
                                                                                 position=Point3d(x=p.x, y=p.y, z=0)))
             for _ in range(1, 7):
-                p = start_point.polar(0.20*i+randint(-5, 5)*0.01,
-                                                        self.robot_locator.pose.yaw) \
+                p = start_point.polar(0.20*i+randint(-5, 5)*0.01, self.robot_locator.pose.yaw) \
                     .polar(randint(-15, 15)*0.01, self.robot_locator.pose.yaw + np.pi/2)
                 self.detector.simulated_objects.append(rosys.vision.SimulatedObject(category_name='weed',
                                                                                     position=Point3d(x=p.x, y=p.y, z=0)))

--- a/field_friend/automations/plant_locator.py
+++ b/field_friend/automations/plant_locator.py
@@ -146,7 +146,7 @@ class PlantLocator(EntityLocator):
             elif d.category_name in self.crop_category_names and d.confidence >= self.minimum_crop_confidence:
                 self.plant_provider.add_crop(plant)
             elif d.category_name not in self.crop_category_names and d.category_name not in self.weed_category_names:
-                self.log.info(f'{d.category_name} not in categories')
+                self.log.error('Detected category "%s" is unknown', d.category_name)
 
     def _detection_watchdog(self) -> None:
         if self.is_paused:

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -24,12 +24,7 @@ from .automations import (
     Puncher,
 )
 from .automations.implements import Implement, Recorder, Tornado, WeedingScrew
-from .automations.navigation import (
-    CrossglideDemoNavigation,
-    FieldNavigation,
-    Navigation,
-    StraightLineNavigation,
-)
+from .automations.navigation import CrossglideDemoNavigation, FieldNavigation, Navigation, StraightLineNavigation
 from .config import get_config
 from .hardware import AxisD1, FieldFriend, FieldFriendHardware, FieldFriendSimulation, TeltonikaRouter
 from .info import Info
@@ -70,7 +65,8 @@ class System(rosys.persistence.Persistable):
                 self.log.exception(f'failed to initialize FieldFriendHardware {self.robot_id}')
             assert isinstance(self.field_friend, FieldFriendHardware)
             self.gnss = self.setup_gnss()
-            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent(restore=self.restore_persistence)
+            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu) \
+                .persistent(restore=self.restore_persistence)
             self.mjpeg_camera_provider = rosys.vision.MjpegCameraProvider(username='root', password='zauberzg!')
             self.detector = rosys.vision.DetectorHardware(port=8004)
             self.monitoring_detector = rosys.vision.DetectorHardware(port=8005)
@@ -78,7 +74,8 @@ class System(rosys.persistence.Persistable):
             self.field_friend = FieldFriendSimulation(self.config, use_acceleration=use_acceleration)
             assert isinstance(self.field_friend.wheels, rosys.hardware.WheelsSimulation)
             self.gnss = self.setup_gnss(self.field_friend.wheels)
-            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent(restore=self.restore_persistence)
+            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu) \
+                .persistent(restore=self.restore_persistence)
             # NOTE we run this in rosys.startup to enforce setup AFTER the persistence is loaded
             rosys.on_startup(self.setup_simulated_usb_camera)
             if self.camera_provider is not None:
@@ -247,8 +244,10 @@ class System(rosys.persistence.Persistable):
 
     def setup_navigations(self) -> None:
         first_implement = next(iter(self.implements.values()))
-        self.straight_line_navigation = StraightLineNavigation(self, first_implement).persistent(restore=self.restore_persistence)
-        self.field_navigation = FieldNavigation(self, first_implement).persistent(restore=self.restore_persistence) if self.gnss is not None else None
+        self.straight_line_navigation = StraightLineNavigation(self, first_implement) \
+            .persistent(restore=self.restore_persistence)
+        self.field_navigation = FieldNavigation(self, first_implement) \
+            .persistent(restore=self.restore_persistence) if self.gnss is not None else None
         self.crossglide_demo_navigation = CrossglideDemoNavigation(self, first_implement).persistent(restore=self.restore_persistence) \
             if isinstance(self.field_friend.y_axis, AxisD1) else None
         self.navigation_strategies = {n.name: n for n in [self.straight_line_navigation,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pre-commit
 pylint
 pytest
 pytest-asyncio
+ruff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ async def system_with_tornado(rosys_integration, request) -> AsyncGenerator[Syst
     assert s.gnss.last_measurement.point.distance(GeoReference.current.origin) == pytest.approx(0, abs=1e-8)
     yield s
 
+
 @pytest.fixture
 async def system_with_acceleration(rosys_integration) -> AsyncGenerator[System, None]:
     # TODO: solve in RoSys


### PR DESCRIPTION
### Motivation

We noticed that turning the robot on the spot when changing rows is quite destructive to wet or loose soil. It also carries quite a lot of soil into the tracks of the field friend. @SeaTechRC thought of a three-point-turn to change rows, thanks for that!

### Implementation

Like the space efficient way to turn a car, the robot will now do a three step manouver. The wanted radius can be set in the field navigation options. For now I left a developer option, to use the old turn, but I think we can remove that, when we are done testing.

What I've done so far:
- Add three-point-turn
- Fix formatting
- Make some logging more clear
- Add ruff to the developer requirements

ToDos:
- [ ] For some reason, the tests fail with a radius of 1.5m, but work perfectly fine with 1.499 and 1.501
- [ ] Test it
- [ ] Remove old turn and the developer option


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [ ] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
