### PR TITLE
Update RoSys, implement the driver's minimum speed limit and remove persistence workaround

### DIFF
--- a/config/f20.py
+++ b/config/f20.py
@@ -1,0 +1,42 @@
+from rosys.geometry import Pose, Rotation
+
+from field_friend.config import (
+    BumperConfiguration,
+    CircleSightPositions,
+    FieldFriendConfiguration,
+    GnssConfiguration,
+    ImuConfiguration,
+    MeasurementsConfiguration,
+    RobotBrainConfiguration,
+    WheelsConfiguration,
+)
+
+config = FieldFriendConfiguration(
+    name='fieldfriend-f20',
+    robot_brain=RobotBrainConfiguration(name='rb39', flash_params=['orin', 'v05', 'nand']),
+    tool=None,
+    measurements=MeasurementsConfiguration(tooth_count=15, pitch=0.033, work_x=0.47),
+    camera=None,
+    wheels=WheelsConfiguration(
+        is_left_reversed=True,
+        is_right_reversed=False,
+        left_back_can_address=0x000,
+        left_front_can_address=0x100,
+        right_back_can_address=0x200,
+        right_front_can_address=0x300,
+        odrive_version=6,
+    ),
+    has_status_control=True,
+    flashlight=None,
+    bumper=BumperConfiguration(pin_front_top=21, pin_front_bottom=35, pin_back=18),
+    y_axis=None,
+    z_axis=None,
+    circle_sight_positions=CircleSightPositions(
+        right='-4',
+        back='-2',
+        front='-1',
+        left='-3',
+    ),
+    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6036453, 0.0084839, 0.0), min_gyro_calibration=0.0),
+    gnss=GnssConfiguration(antenna_pose=Pose(x=-0.003, y=0.255, yaw=0.0)),
+)

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -38,7 +38,7 @@ icecream.install()
 
 class System(rosys.persistence.Persistable):
 
-    def __init__(self, robot_id: str, *, use_acceleration: bool = True) -> None:
+    def __init__(self, robot_id: str, *, use_acceleration: bool = False) -> None:
         super().__init__()
         self.robot_id = robot_id
         assert self.robot_id != 'unknown'

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -24,12 +24,7 @@ from .automations import (
     Puncher,
 )
 from .automations.implements import Implement, Recorder, Tornado, WeedingScrew
-from .automations.navigation import (
-    CrossglideDemoNavigation,
-    FieldNavigation,
-    Navigation,
-    StraightLineNavigation,
-)
+from .automations.navigation import CrossglideDemoNavigation, FieldNavigation, Navigation, StraightLineNavigation
 from .config import get_config
 from .hardware import AxisD1, FieldFriend, FieldFriendHardware, FieldFriendSimulation, TeltonikaRouter
 from .info import Info
@@ -43,11 +38,10 @@ icecream.install()
 
 class System(rosys.persistence.Persistable):
 
-    def __init__(self, robot_id: str, *, restore_persistence: bool = True, use_acceleration: bool = True) -> None:
+    def __init__(self, robot_id: str, *, use_acceleration: bool = True) -> None:
         super().__init__()
         self.robot_id = robot_id
         assert self.robot_id != 'unknown'
-        self.restore_persistence = restore_persistence
         rosys.hardware.SerialCommunication.search_paths.insert(0, '/dev/ttyTHS0')
         self.log = logging.getLogger('field_friend.system')
         self.is_real = rosys.hardware.SerialCommunication.is_possible()
@@ -70,7 +64,7 @@ class System(rosys.persistence.Persistable):
                 self.log.exception(f'failed to initialize FieldFriendHardware {self.robot_id}')
             assert isinstance(self.field_friend, FieldFriendHardware)
             self.gnss = self.setup_gnss()
-            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent(restore=self.restore_persistence)
+            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent()
             self.mjpeg_camera_provider = rosys.vision.MjpegCameraProvider(username='root', password='zauberzg!')
             self.detector = rosys.vision.DetectorHardware(port=8004)
             self.monitoring_detector = rosys.vision.DetectorHardware(port=8005)
@@ -78,7 +72,7 @@ class System(rosys.persistence.Persistable):
             self.field_friend = FieldFriendSimulation(self.config, use_acceleration=use_acceleration)
             assert isinstance(self.field_friend.wheels, rosys.hardware.WheelsSimulation)
             self.gnss = self.setup_gnss(self.field_friend.wheels)
-            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent(restore=self.restore_persistence)
+            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent()
             # NOTE we run this in rosys.startup to enforce setup AFTER the persistence is loaded
             rosys.on_startup(self.setup_simulated_usb_camera)
             if self.camera_provider is not None:
@@ -90,8 +84,8 @@ class System(rosys.persistence.Persistable):
                 self.camera_provider, robot_locator=self.robot_locator, robot_id=self.robot_id, camera_config=self.config.camera)
         self.odometer = Odometer(self.field_friend.wheels)
         self.setup_driver()
-        self.plant_provider = PlantProvider().persistent(restore=self.restore_persistence)
-        self.kpi_provider = KpiProvider().persistent(restore=self.restore_persistence)
+        self.plant_provider = PlantProvider().persistent()
+        self.kpi_provider = KpiProvider().persistent()
         if not self.is_real:
             generate_kpis(self.kpi_provider)
 
@@ -102,12 +96,12 @@ class System(rosys.persistence.Persistable):
                 self.kpi_provider.increment_on_rising_edge('low_battery', self.field_friend.bms.is_below_percent(10.0))
 
         self.puncher: Puncher = Puncher(self.field_friend, self.driver)
-        self.plant_locator: PlantLocator = PlantLocator(self).persistent(restore=self.restore_persistence)
+        self.plant_locator: PlantLocator = PlantLocator(self).persistent()
 
         rosys.on_repeat(watch_robot, 1.0)
 
-        self.path_provider: PathProvider = PathProvider().persistent(restore=self.restore_persistence)
-        self.field_provider: FieldProvider = FieldProvider().persistent(restore=self.restore_persistence)
+        self.path_provider: PathProvider = PathProvider().persistent()
+        self.field_provider: FieldProvider = FieldProvider().persistent()
         self.setup_shape()
         self.automator: rosys.automation.Automator = rosys.automation.Automator(
             self.steerer, on_interrupt=self.field_friend.stop)
@@ -229,10 +223,10 @@ class System(rosys.persistence.Persistable):
         match self.field_friend.implement_name:
             case 'tornado':
                 implements.append(Recorder(self))
-                implements.append(Tornado(self).persistent(key=persistence_key, restore=self.restore_persistence))
+                implements.append(Tornado(self).persistent(key=persistence_key, ))
             case 'weed_screw':
                 implements.append(Recorder(self))
-                implements.append(WeedingScrew(self).persistent(key=persistence_key, restore=self.restore_persistence))
+                implements.append(WeedingScrew(self).persistent(key=persistence_key, ))
             case 'dual_mechanism':
                 # implements.append(WeedingScrew(self))
                 # implements.append(ChopAndScrew(self))
@@ -248,9 +242,9 @@ class System(rosys.persistence.Persistable):
 
     def setup_navigations(self) -> None:
         first_implement = next(iter(self.implements.values()))
-        self.straight_line_navigation = StraightLineNavigation(self, first_implement).persistent(restore=self.restore_persistence)
-        self.field_navigation = FieldNavigation(self, first_implement).persistent(restore=self.restore_persistence) if self.gnss is not None else None
-        self.crossglide_demo_navigation = CrossglideDemoNavigation(self, first_implement).persistent(restore=self.restore_persistence) \
+        self.straight_line_navigation = StraightLineNavigation(self, first_implement).persistent()
+        self.field_navigation = FieldNavigation(self, first_implement).persistent() if self.gnss is not None else None
+        self.crossglide_demo_navigation = CrossglideDemoNavigation(self, first_implement).persistent() \
             if isinstance(self.field_friend.y_axis, AxisD1) else None
         self.navigation_strategies = {n.name: n for n in [self.straight_line_navigation,
                                                           self.field_navigation,
@@ -265,9 +259,9 @@ class System(rosys.persistence.Persistable):
             self.log.warning('Camera is not configured, no camera provider will be used')
             return None
         if self.config.camera.camera_type == 'CalibratableUsbCamera':
-            return CalibratableUsbCameraProvider().persistent(restore=self.restore_persistence)
+            return CalibratableUsbCameraProvider().persistent()
         if self.config.camera.camera_type == 'ZedxminiCamera':
-            return ZedxminiCameraProvider().persistent(restore=self.restore_persistence)
+            return ZedxminiCameraProvider().persistent()
         raise NotImplementedError(f'Unknown camera type: {self.config.camera.camera_type}')
 
     async def setup_simulated_usb_camera(self):

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -207,6 +207,7 @@ class System(rosys.persistence.Persistable):
         self.driver.parameters.carrot_offset = self.driver.parameters.hook_offset + self.driver.parameters.carrot_distance
         self.driver.parameters.hook_bending_factor = 0.25
         self.driver.parameters.minimum_drive_distance = 0.005
+        self.driver.parameters.throttle_at_end_min_speed = 0.05
 
     def setup_shape(self) -> None:
         width = 0.64

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-# rosys == v0.25.0
-rosys @ git+https://github.com/zauberzeug/rosys.git@32c56d3d57f3e2eb5d0ce72b14f36022fb55731d
+# rosys == v0.26.0
+rosys @ git+https://github.com/zauberzeug/rosys/commit/965e7984bceabded790702e733e87b47627be313
 shapely
 uvicorn == 0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pillow
 prompt-toolkit # for lizard monitor
 pynmea2
 # rosys == v0.26.0
-rosys @ git+https://github.com/zauberzeug/rosys/commit/965e7984bceabded790702e733e87b47627be313
+rosys @ git+https://github.com/zauberzeug/rosys.git@965e7984bceabded790702e733e87b47627be313
 shapely
 uvicorn == 0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-# rosys == v0.26.0
-rosys @ git+https://github.com/zauberzeug/rosys.git@965e7984bceabded790702e733e87b47627be313
+rosys == v0.26.0
 shapely
 uvicorn == 0.28.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import pytest
 import rosys
 from rosys.geometry import GeoPoint, GeoReference
 from rosys.hardware import GnssSimulation
-from rosys.persistence import Persistable
 from rosys.testing import forward, helpers
 
 from field_friend.automations import Field, Row
@@ -24,9 +23,7 @@ log = logging.getLogger('field_friend.testing')
 
 @pytest.fixture
 async def system(rosys_integration, request) -> AsyncGenerator[System, None]:
-    # TODO: solve in RoSys
-    Persistable.instances.clear()
-    s = System(getattr(request, 'param', 'u6'), restore_persistence=False)
+    s = System(getattr(request, 'param', 'u6'))
     assert isinstance(s.detector, rosys.vision.DetectorSimulation)
     s.detector.detection_delay = 0.1
     GeoReference.update_current(GEO_REFERENCE)
@@ -43,9 +40,7 @@ async def system(rosys_integration, request) -> AsyncGenerator[System, None]:
 
 @pytest.fixture
 async def system_with_tornado(rosys_integration, request) -> AsyncGenerator[System, None]:
-    # TODO: solve in RoSys
-    Persistable.instances.clear()
-    s = System(getattr(request, 'param', 'u4'), restore_persistence=False)
+    s = System(getattr(request, 'param', 'u4'))
     assert isinstance(s.detector, rosys.vision.DetectorSimulation)
     s.detector.detection_delay = 0.1
     GeoReference.update_current(GEO_REFERENCE)
@@ -59,11 +54,10 @@ async def system_with_tornado(rosys_integration, request) -> AsyncGenerator[Syst
     assert s.gnss.last_measurement.point.distance(GeoReference.current.origin) == pytest.approx(0, abs=1e-8)
     yield s
 
+
 @pytest.fixture
 async def system_with_acceleration(rosys_integration) -> AsyncGenerator[System, None]:
-    # TODO: solve in RoSys
-    Persistable.instances.clear()
-    s = System('u4', restore_persistence=False, use_acceleration=True)
+    s = System('u4', use_acceleration=True)
     assert isinstance(s.field_friend.wheels, WheelsSimulationWithAcceleration)
     assert isinstance(s.detector, rosys.vision.DetectorSimulation)
     s.detector.detection_delay = 0.1

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -135,15 +135,21 @@ async def test_deceleration_different_distances(system_with_acceleration: System
     assert isinstance(system.field_friend.wheels, WheelsSimulationWithAcceleration)
     assert isinstance(system.current_navigation, StraightLineNavigation)
     system.current_navigation.length = distance
-    system.current_navigation.linear_speed_limit = 0.3
+    system.current_navigation.linear_speed_limit = 0.13
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
     await forward(until=lambda: system.automator.is_stopped)
-    assert system.robot_locator.pose.point.x == pytest.approx(distance, abs=0.0005)
+    assert system.robot_locator.pose.point.x == pytest.approx(distance, abs=0.001)
 
 
-@pytest.mark.parametrize('linear_speed_limit', (0.1, 0.13, 0.2, 0.3, 0.4))
-async def test_deceleration_different_speeds(system_with_acceleration: System, linear_speed_limit: float):
+@pytest.mark.parametrize(('linear_speed_limit', 'tolerance'), [
+    (0.1, 0.0005),
+    (0.13, 0.001),
+    (0.2, 0.001),
+    (0.3, 0.0013),
+    (0.4, 0.0013),
+])
+async def test_deceleration_different_speeds(system_with_acceleration: System, linear_speed_limit: float, tolerance: float):
     """Try stop after 1mm with different speeds with a tolerance of 0.2mm"""
     system = system_with_acceleration
     assert isinstance(system.field_friend.wheels, WheelsSimulationWithAcceleration)
@@ -153,7 +159,7 @@ async def test_deceleration_different_speeds(system_with_acceleration: System, l
     system.automator.start()
     await forward(until=lambda: system.automator.is_running)
     await forward(until=lambda: system.automator.is_stopped)
-    assert system.robot_locator.pose.point.x == pytest.approx(0.005, abs=0.0005)
+    assert system.robot_locator.pose.point.x == pytest.approx(0.005, abs=tolerance)
 
 
 @pytest.mark.parametrize('heading_degrees', (-180, -90, 0, 90, 180, 360))


### PR DESCRIPTION
### Motivation

The upcoming [RoSys release](https://github.com/zauberzeug/rosys/releases/tag/v0.26.0) will have some helpful additions and fixes.

### Implementation

1. https://github.com/zauberzeug/rosys/pull/302
2. https://github.com/zauberzeug/rosys/pull/303
    - I set `throttle_at_end_min_speed` to 0.05
    - As expected with a minimum speed, deceleration distances will change. That's why I adjusted tolerances in the tests.
    - I set `use_acceleration` to `False` by default, because we have tests for it and it's annoying in simulation
4. https://github.com/zauberzeug/rosys/pull/304
5. https://github.com/zauberzeug/rosys/pull/306
    - I removed the workaround for the test fixtures
6. I added and tested the F20 config, which is only for testing because it belongs to another project

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
    - [x] Wait for [RoSys 0.26.0](https://github.com/zauberzeug/rosys/releases/tag/v0.26.0) 
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
