### PR TITLE
Set speed limits for navigation settings

### DIFF
--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -196,7 +196,13 @@ class Navigation(rosys.persistence.Persistable):
         pass
 
     def settings_ui(self) -> None:
-        ui.number('Linear Speed', step=0.01, min=0.01, max=1.0, format='%.2f', suffix='m/s', on_change=self.request_backup) \
+        ui.number('Linear Speed',
+                  step=0.01,
+                  min=self.driver.parameters.throttle_at_end_min_speed,
+                  max=self.driver.parameters.linear_speed_limit,
+                  format='%.2f',
+                  suffix='m/s',
+                  on_change=self.request_backup) \
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'linear_speed_limit') \

--- a/field_friend/automations/navigation/navigation.py
+++ b/field_friend/automations/navigation/navigation.py
@@ -206,7 +206,7 @@ class Navigation(rosys.persistence.Persistable):
             .props('dense outlined') \
             .classes('w-24') \
             .bind_value(self, 'linear_speed_limit') \
-            .tooltip(f'Forward speed limit in m/s (default: {self.LINEAR_SPEED_LIMIT:.2f})')
+            .tooltip(f'Forward speed limit between {self.driver.parameters.throttle_at_end_min_speed} and {self.driver.parameters.linear_speed_limit} m/s (default: {self.LINEAR_SPEED_LIMIT:.2f})')
 
 
 def is_reference_valid(gnss: Gnss | None, *, max_distance: float = 5000.0) -> bool:


### PR DESCRIPTION
### Motivation

The robot currently can't handle higher speeds and is mostly tested for about 0.3 m/s. This PR will limit the speed input to avoid driving issues.

### Implementation

- Use the driver's speed limits for the speed input field
- Add information about it in the tooltip

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
