### PR TITLE
Switch monitoring to new CircleSight project

### DIFF
--- a/.syncignore
+++ b/.syncignore
@@ -4,13 +4,16 @@
 .mypy_cache/
 .pytest_cache/
 .vscode/
+.ruff_cache/
 tests/
 \*.swp
 .env
 config.hjson
 sync.sh
+field_friend.egg-info/
 nicegui
 rosys
+site
 .nicegui
 .venv
 .DS_Store

--- a/docker-compose.jetson.orin.yml
+++ b/docker-compose.jetson.orin.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - ~/data_plants:/data
 
-  monitoring:
+  circle_sight:
     image: "zauberzeug/yolov5-detector:0.1.11-nlv0.14.0-35.4.1"
     restart: always
     ports:

--- a/docker-compose.jetson.orin.yml
+++ b/docker-compose.jetson.orin.yml
@@ -28,10 +28,10 @@ services:
     environment:
       - HOST=learning-loop.ai
       - ORGANIZATION=zauberzeug
-      - PROJECT=monitoring
+      - PROJECT=circlesight
       - NVIDIA_VISIBLE_DEVICES=all
     volumes:
-      - ~/data_monitoring:/data
+      - ~/data_circlesight:/data
 
   autoheal:
     restart: always

--- a/docker-compose.jetson.yml
+++ b/docker-compose.jetson.yml
@@ -13,11 +13,11 @@ services:
     hostname: ${ROBOT_ID}
     environment:
       - HOST=learning-loop.ai
-      - ORGANIZATION=zauberzeug
-      - PROJECT=coins
+      - ORGANIZATION=feldfreund
+      - PROJECT=plants
       - NVIDIA_VISIBLE_DEVICES=all
     volumes:
-      - ~/data_coins:/data
+      - ~/data_plants:/data
 
   circle_sight:
     image: "zauberzeug/yolov5-detector:nlv0.8.8-32.6.1"

--- a/docker-compose.jetson.yml
+++ b/docker-compose.jetson.yml
@@ -28,10 +28,10 @@ services:
     environment:
       - HOST=learning-loop.ai
       - ORGANIZATION=zauberzeug
-      - PROJECT=monitoring
+      - PROJECT=circlesight
       - NVIDIA_VISIBLE_DEVICES=all
     volumes:
-      - ~/data_monitoring:/data
+      - ~/data_circlesight:/data
 
   autoheal:
     restart: always

--- a/field_friend/interface/components/monitoring.py
+++ b/field_friend/interface/components/monitoring.py
@@ -22,7 +22,7 @@ class Monitoring:
         # TODO: in simulation there is no mjpeg camera provider
         self.mjpg_camera_provider = getattr(system, 'mjpeg_camera_provider', None)
         self.detector = getattr(system, 'detector', None)
-        self.monitoring_detector = getattr(system, 'monitoring_detector', None)
+        self.monitoring_detector = getattr(system, 'circle_sight_detector', None)
         self.monitoring_active = False
         self.plant_locator = getattr(system, 'plant_locator', None)
         self.field_friend = system.field_friend

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -67,7 +67,7 @@ class System(rosys.persistence.Persistable):
             self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent()
             self.mjpeg_camera_provider = rosys.vision.MjpegCameraProvider(username='root', password='zauberzg!')
             self.detector = rosys.vision.DetectorHardware(port=8004)
-            self.monitoring_detector = rosys.vision.DetectorHardware(port=8005)
+            self.circle_sight_detector = rosys.vision.DetectorHardware(port=8005)
         else:
             self.field_friend = FieldFriendSimulation(self.config, use_acceleration=use_acceleration)
             assert isinstance(self.field_friend.wheels, rosys.hardware.WheelsSimulation)


### PR DESCRIPTION
### Motivation

We switched to a new learning loop project, specialized for the fieldfriend circle sight.

### Implementation
It's not exactly a breaking change, like the tag suggests, but it can lead to orphan containers since the service was renamed.

- Switch to new project
- Update old compose file to fieldfriend plant project
- Small cleanups

How to:

1. Stop and remove monitoring container
2. Rename `~/data_monitoring` directory to `~/data_circlesight`
3. `./docker.sh U`


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
