### PR TITLE
Update to RoSys 0.28.0

### DIFF
--- a/field_friend/app_controls.py
+++ b/field_friend/app_controls.py
@@ -13,7 +13,8 @@ class AppControls(RosysAppControls):
                  robot_brain: RobotBrain,
                  automator: Automator,
                  field_friend: FieldFriend,
-                 capture: Capture,
+                 *,
+                 capture: Capture | None = None,
                  ) -> None:
         super().__init__(robot_brain, automator)
         self.field_friend = field_friend
@@ -25,9 +26,10 @@ class AppControls(RosysAppControls):
         self.last_bumpers_active: list[str] = []
         self.last_info: str = ''
         self.APP_CONNECTED.register(self.reset)
-        self.extra_buttons['front'] = \
-            AppButton('file_upload', released=self.capture.front)
-        self.extra_buttons['inner'] = AppButton('file_download', released=self.capture.inner)
+        if self.capture:
+            self.extra_buttons['front'] = \
+                AppButton('file_upload', released=self.capture.front)
+            self.extra_buttons['inner'] = AppButton('file_download', released=self.capture.inner)
         rosys.on_repeat(self.check_status, 2.0)
 
     async def check_status(self) -> None:

--- a/field_friend/automations/navigation/__init__.py
+++ b/field_friend/automations/navigation/__init__.py
@@ -1,7 +1,7 @@
 from .field_navigation import FieldNavigation, RowSegment
 from .implement_demo_navigation import ImplementDemoNavigation
 from .straight_line_navigation import StraightLineNavigation
-from .waypoint_navigation import DriveSegment, WaypointNavigation, WorkflowException
+from .waypoint_navigation import DriveSegment, WaypointNavigation, WorkflowException, is_reference_valid
 
 __all__ = [
     'DriveSegment',
@@ -11,4 +11,5 @@ __all__ = [
     'StraightLineNavigation',
     'WaypointNavigation',
     'WorkflowException',
+    'is_reference_valid',
 ]

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -12,11 +12,10 @@ from shapely.geometry import Point as ShapelyPoint
 from shapely.geometry import Polygon as ShapelyPolygon
 
 from ..field import Field, Row
-from ..implements import WeedingImplement
+from ..implements import Implement, WeedingImplement
 from .waypoint_navigation import DriveSegment, WaypointNavigation
 
 if TYPE_CHECKING:
-    from ...automations.implements.implement import Implement
     from ...system import System
 
 

--- a/field_friend/automations/navigation/waypoint_navigation.py
+++ b/field_friend/automations/navigation/waypoint_navigation.py
@@ -130,10 +130,11 @@ class WaypointNavigation(rosys.persistence.Persistable):
         """Prepares the navigation for the start of the automation
 
         Returns true if all preparations were successful, otherwise false."""
-        self.plant_provider.clear()
+        if self.plant_provider is not None:
+            self.log.debug('Clearing plant provider')
+            self.plant_provider.clear()
         if isinstance(self.detector, rosys.vision.DetectorSimulation) and not rosys.is_test:
             self.detector.simulated_objects = []
-        self.log.info('clearing plant provider')
         self._upcoming_path = self.generate_path()
         if not self._upcoming_path:
             self.log.error('Path generation failed')
@@ -153,7 +154,8 @@ class WaypointNavigation(rosys.persistence.Persistable):
         segment: DriveSegment | None
         if isinstance(self.detector, rosys.vision.DetectorSimulation) and not rosys.is_test:
             self.detector.simulated_objects.clear()
-            self.system.plant_provider.clear()
+            if self.plant_provider is not None:
+                self.plant_provider.clear()
             for segment in self._upcoming_path:
                 if segment.use_implement:
                     self.create_segment_simulation(segment)

--- a/field_friend/interface/dev_page.py
+++ b/field_friend/interface/dev_page.py
@@ -72,6 +72,7 @@ class DevPage:
             if self.system.gnss is not None:
                 with ui.card():
                     self.system.gnss.developer_ui()
+                    ui.button('Update reference', on_click=self.system.update_gnss_reference)
             if isinstance(self.system.field_friend.imu, rosys.hardware.Imu):
                 with ui.card():
                     self.system.field_friend.imu.developer_ui()

--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -46,7 +46,7 @@ class RobotLocator(rosys.persistence.Persistable):
         self._wheels.VELOCITY_MEASURED.register(self._handle_velocity_measurement)
         if self._gnss is not None:
             self._gnss.NEW_MEASUREMENT.register(self._handle_gnss_measurement)
-        rosys.on_startup(self._reset)
+        rosys.on_startup(self.reset)
 
     def backup_to_dict(self) -> dict[str, Any]:
         return {
@@ -185,7 +185,7 @@ class RobotLocator(rosys.persistence.Persistable):
         self.pose_frame.y = self._x[1, 0]
         self.pose_frame.rotation = Rotation.from_euler(0, 0, self._x[2, 0])
 
-    async def _reset(self, *, gnss_timeout: float = 2.0) -> None:
+    async def reset(self, *, gnss_timeout: float = 2.0) -> None:
         reset_pose = Pose(x=0.0, y=0.0, yaw=0.0)
         r_xy = 0.0
         r_theta = 0.0
@@ -238,5 +238,5 @@ class RobotLocator(rosys.persistence.Persistable):
                     ui.number(label='ω odom weight', min=0, step=0.01, format='%.3f', value=self._odometry_angular_weight, on_change=self.request_backup) \
                         .bind_value_to(self, '_odometry_angular_weight')
 
-            ui.button('Reset', on_click=self._reset) \
+            ui.button('Reset', on_click=self.reset) \
                 .tooltip('Reset the position to the GNSS measurement or zero position if GNSS is not available or ignored.')

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -288,7 +288,7 @@ class System(rosys.persistence.Persistable):
             return None
         if self.is_real:
             gnss_hardware = GnssHardware(antenna_pose=self.config.gnss.antenna_pose)
-            gnss_hardware.MAX_TIMESTAMP_DIFF = 0.1
+            gnss_hardware.MAX_TIMESTAMP_DIFF = 0.25
             return gnss_hardware
         assert isinstance(wheels, rosys.hardware.WheelsSimulation)
         if rosys.is_test:

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -42,6 +42,7 @@ class System(rosys.persistence.Persistable):
         super().__init__()
         self.robot_id = robot_id
         assert self.robot_id != 'unknown'
+        self.config = get_config(self.robot_id)
         rosys.hardware.SerialCommunication.search_paths.insert(0, '/dev/ttyTHS0')
         self.log = logging.getLogger('field_friend.system')
         self.is_real = rosys.hardware.SerialCommunication.is_possible()
@@ -83,8 +84,10 @@ class System(rosys.persistence.Persistable):
         self.capture = Capture(self)
         if self.config.camera is not None:
             assert self.camera_provider is not None
-            self.camera_configurator = CameraConfigurator(
-                self.camera_provider, robot_locator=self.robot_locator, robot_id=self.robot_id, camera_config=self.config.camera)
+            self.camera_configurator = CameraConfigurator(self.camera_provider,
+                                                          robot_locator=self.robot_locator,
+                                                          robot_id=self.robot_id,
+                                                          camera_config=self.config.camera)
         self.odometer = Odometer(self.field_friend.wheels)
         self.setup_driver()
         self.plant_provider = PlantProvider().persistent()
@@ -124,7 +127,7 @@ class System(rosys.persistence.Persistable):
             assert isinstance(self.field_friend, FieldFriendHardware)
             if self.field_friend.battery_control:
                 self.battery_watcher = BatteryWatcher(self.field_friend, self.automator)
-            app_controls(self.field_friend.robot_brain, self.automator, self.field_friend, self.capture)
+            app_controls(self.field_friend.robot_brain, self.automator, self.field_friend, capture=self.capture)
             rosys.on_repeat(self.log_status, 60 * 5)
         rosys.on_repeat(self._garbage_collection, 60*5)
         rosys.config.garbage_collection_mbyte_limit = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "field_friend"
 version = "0.10.0-dev"
 description = "Zauberzeug Field Friend with RoSys"
 authors = [{ name="Zauberzeug", email="info@zauberzeug.com" }]
-requires-python = ">=3.12, <3.13"
+requires-python = ">=3.11, <3.14"
 readme = "README.md"
 
 [tool.mypy]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-rosys == 0.27.0
+rosys == 0.28.0
 shapely
 uvicorn == 0.28.1


### PR DESCRIPTION
### Motivation & Implementation

This PR updates to [RoSys 0.28.0](https://github.com/zauberzeug/rosys/releases/tag/v0.28.0) and does some minor changes to make this library easier to handle for other projects.

- Update RoSys and allow python versions 3.11, 3.12 and 3.13
- Make `is_reference_valid` and `RobotLocator.reset` public
- Add the `GNSS_REFERENCE_CHANGED` event to `System`
- Raise `GnssHardware.MAX_TIMESTAMP_DIFF` to 0.25 seconds
- Minor cleanups to make it usable for other non field friend hardware

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
