### PR TITLE
Correct GNSS position with roll and pitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/reference/
 .venv/
 .DS_Store
 .mypy_cache/
+test.py

--- a/.syncignore
+++ b/.syncignore
@@ -17,3 +17,4 @@ site
 .nicegui
 .venv
 .DS_Store
+test.py

--- a/config/f12.py
+++ b/config/f12.py
@@ -81,7 +81,6 @@ config = FieldFriendConfiguration(
         turn_speed_limit=1.5,
     ),
     gnss=GnssConfiguration(),
-    # TODO: add IMU, when the next stable version is released
-    # ImuConfiguration(offset_rotation=Rotation.from_euler(0.0, 0, 0))
+    # TODO: add IMU configuration
     imu=None,
 )

--- a/config/f12.py
+++ b/config/f12.py
@@ -1,4 +1,3 @@
-from rosys.geometry import Pose
 
 from field_friend.config.configuration import (  # ImuConfiguration,
     BumperConfiguration,
@@ -81,7 +80,7 @@ config = FieldFriendConfiguration(
         ref_motor_pin=35,
         turn_speed_limit=1.5,
     ),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(),
     # TODO: add IMU, when the next stable version is released
     # ImuConfiguration(offset_rotation=Rotation.from_euler(0.0, 0, 0))
     imu=None,

--- a/config/f12.py
+++ b/config/f12.py
@@ -1,5 +1,4 @@
-
-from field_friend.config.configuration import (  # ImuConfiguration,
+from field_friend.config.configuration import (
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,

--- a/config/f13.py
+++ b/config/f13.py
@@ -93,7 +93,6 @@ config = FieldFriendConfiguration(
         turn_speed_limit=1.5,
     ),
     gnss=GnssConfiguration(),
-    # TODO: add IMU, when the next stable version is released
-    # ImuConfiguration(offset_rotation=Rotation.from_euler(0.0, 0, 0))
+    # TODO: add IMU configuration
     imu=None,
 )

--- a/config/f13.py
+++ b/config/f13.py
@@ -1,5 +1,4 @@
-
-from field_friend.config.configuration import (  # ImuConfiguration,
+from field_friend.config.configuration import (
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,

--- a/config/f13.py
+++ b/config/f13.py
@@ -1,4 +1,3 @@
-from rosys.geometry import Pose
 
 from field_friend.config.configuration import (  # ImuConfiguration,
     BumperConfiguration,
@@ -93,7 +92,7 @@ config = FieldFriendConfiguration(
         ref_motor_pin=5,
         turn_speed_limit=1.5,
     ),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(),
     # TODO: add IMU, when the next stable version is released
     # ImuConfiguration(offset_rotation=Rotation.from_euler(0.0, 0, 0))
     imu=None,

--- a/config/f14.py
+++ b/config/f14.py
@@ -1,11 +1,10 @@
-from rosys.geometry import Rotation
+# from rosys.geometry import Rotation
 
-from field_friend.config import (
+from field_friend.config import (  # ImuConfiguration,
     BumperConfiguration,
     CircleSightPositions,
     FieldFriendConfiguration,
     GnssConfiguration,
-    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     WheelsConfiguration,
@@ -32,5 +31,7 @@ config = FieldFriendConfiguration(
     z_axis=None,
     circle_sight_positions=CircleSightPositions(),
     gnss=GnssConfiguration(),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.5999433, 0.0127409, 0.0)),
+    # TODO: IMU configuration is probably wrong. Check https://github.com/zauberzeug/field_friend/pull/361
+    # imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.5999433, 0.0127409, 0.0)),
+    imu=None,
 )

--- a/config/f14.py
+++ b/config/f14.py
@@ -31,6 +31,6 @@ config = FieldFriendConfiguration(
     y_axis=None,
     z_axis=None,
     circle_sight_positions=CircleSightPositions(),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.5999433, 0.0127409, 0.0)),
     gnss=GnssConfiguration(),
+    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.5999433, 0.0127409, 0.0)),
 )

--- a/config/f14.py
+++ b/config/f14.py
@@ -1,6 +1,4 @@
-# from rosys.geometry import Rotation
-
-from field_friend.config import (  # ImuConfiguration,
+from field_friend.config import (
     BumperConfiguration,
     CircleSightPositions,
     FieldFriendConfiguration,

--- a/config/f15.py
+++ b/config/f15.py
@@ -1,6 +1,4 @@
-# from rosys.geometry import Rotation
-
-from field_friend.config.configuration import (  # ImuConfiguration,
+from field_friend.config.configuration import (
     AxisD1Configuration,
     BumperConfiguration,
     CameraConfiguration,

--- a/config/f15.py
+++ b/config/f15.py
@@ -1,6 +1,6 @@
-from rosys.geometry import Rotation
+# from rosys.geometry import Rotation
 
-from field_friend.config.configuration import (
+from field_friend.config.configuration import (  # ImuConfiguration,
     AxisD1Configuration,
     BumperConfiguration,
     CameraConfiguration,
@@ -9,7 +9,6 @@ from field_friend.config.configuration import (
     FieldFriendConfiguration,
     FlashlightConfiguration,
     GnssConfiguration,
-    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     WheelsConfiguration,
@@ -88,5 +87,7 @@ config = FieldFriendConfiguration(
         reversed_direction=True,
     ),
     gnss=GnssConfiguration(x=0.072),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.570796, 0, 0)),
+    # TODO: IMU configuration is probably wrong. Check https://github.com/zauberzeug/field_friend/pull/361
+    # imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.570796, 0, 0)),
+    imu=None,
 )

--- a/config/f15.py
+++ b/config/f15.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose, Rotation
+from rosys.geometry import Rotation
 
 from field_friend.config.configuration import (
     AxisD1Configuration,
@@ -87,6 +87,6 @@ config = FieldFriendConfiguration(
         axis_offset=-0.01,
         reversed_direction=True,
     ),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.072, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(x=0.072),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.570796, 0, 0)),
 )

--- a/config/f19.py
+++ b/config/f19.py
@@ -47,7 +47,6 @@ config = FieldFriendConfiguration(
     ),
     bumper=BumperConfiguration(pin_front_top=21, pin_front_bottom=35, pin_back=18),
     gnss=GnssConfiguration(),
-    # TODO: add IMU, when the next stable version is released
-    # ImuConfiguration(offset_rotation=Rotation.from_euler(0.0, 0, 0))
+    # TODO: add IMU configuration
     imu=None,
 )

--- a/config/f19.py
+++ b/config/f19.py
@@ -1,4 +1,3 @@
-from rosys.geometry import Pose
 
 from field_friend.config.configuration import (
     BumperConfiguration,
@@ -47,8 +46,7 @@ config = FieldFriendConfiguration(
         back_pin=23,
     ),
     bumper=BumperConfiguration(pin_front_top=21, pin_front_bottom=35, pin_back=18),
-
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(),
     # TODO: add IMU, when the next stable version is released
     # ImuConfiguration(offset_rotation=Rotation.from_euler(0.0, 0, 0))
     imu=None,

--- a/config/f20.py
+++ b/config/f20.py
@@ -1,11 +1,10 @@
-from rosys.geometry import Rotation
+# from rosys.geometry import Rotation
 
-from field_friend.config import (
+from field_friend.config import (  # ImuConfiguration,
     BumperConfiguration,
     CircleSightPositions,
     FieldFriendConfiguration,
     GnssConfiguration,
-    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     WheelsConfiguration,
@@ -38,5 +37,7 @@ config = FieldFriendConfiguration(
         left='-3',
     ),
     gnss=GnssConfiguration(x=-0.003, y=0.255),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6036453, 0.0084839, 0.0), min_gyro_calibration=0.0),
+    # TODO: IMU configuration is probably wrong. Check https://github.com/zauberzeug/field_friend/pull/361
+    # imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6036453, 0.0084839, 0.0), min_gyro_calibration=0.0),
+    imu=None,
 )

--- a/config/f20.py
+++ b/config/f20.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose, Rotation
+from rosys.geometry import Rotation
 
 from field_friend.config import (
     BumperConfiguration,
@@ -37,6 +37,6 @@ config = FieldFriendConfiguration(
         front='-1',
         left='-3',
     ),
+    gnss=GnssConfiguration(x=-0.003, y=0.255),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6036453, 0.0084839, 0.0), min_gyro_calibration=0.0),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=-0.003, y=0.255, yaw=0.0)),
 )

--- a/config/f20.py
+++ b/config/f20.py
@@ -1,6 +1,4 @@
-# from rosys.geometry import Rotation
-
-from field_friend.config import (  # ImuConfiguration,
+from field_friend.config import (
     BumperConfiguration,
     CircleSightPositions,
     FieldFriendConfiguration,

--- a/config/f21.py
+++ b/config/f21.py
@@ -1,6 +1,4 @@
-# from rosys.geometry import Rotation
-
-from field_friend.config.configuration import (  # ImuConfiguration,
+from field_friend.config.configuration import (
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,

--- a/config/f21.py
+++ b/config/f21.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose, Rotation
+from rosys.geometry import Rotation
 
 from field_friend.config.configuration import (
     BumperConfiguration,
@@ -51,7 +51,6 @@ config = FieldFriendConfiguration(
         front='-1',
         back='-2',
     ),
-    # gnss height: 0.622
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.093, y=0.255, yaw=0.0)),
+    gnss=GnssConfiguration(x=0.093, y=0.255, z=0.665),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6241204, 0.0017964, 0.0)),
 )

--- a/config/f21.py
+++ b/config/f21.py
@@ -1,13 +1,12 @@
-from rosys.geometry import Rotation
+# from rosys.geometry import Rotation
 
-from field_friend.config.configuration import (
+from field_friend.config.configuration import (  # ImuConfiguration,
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,
     FieldFriendConfiguration,
     FlashlightConfiguration,
     GnssConfiguration,
-    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     SprayerConfiguration,
@@ -52,5 +51,7 @@ config = FieldFriendConfiguration(
         back='-2',
     ),
     gnss=GnssConfiguration(x=0.093, y=0.255, z=0.665),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6241204, 0.0017964, 0.0)),
+    # TODO: IMU configuration is probably wrong. Check https://github.com/zauberzeug/field_friend/pull/361
+    # imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6241204, 0.0017964, 0.0)),
+    imu=None,
 )

--- a/config/f22.py
+++ b/config/f22.py
@@ -1,6 +1,4 @@
-# from rosys.geometry import Rotation
-
-from field_friend.config.configuration import (  # ImuConfiguration,
+from field_friend.config.configuration import (
     FieldFriendConfiguration,
     GnssConfiguration,
     MeasurementsConfiguration,

--- a/config/f22.py
+++ b/config/f22.py
@@ -1,9 +1,8 @@
-from rosys.geometry import Rotation
+# from rosys.geometry import Rotation
 
-from field_friend.config.configuration import (
+from field_friend.config.configuration import (  # ImuConfiguration,
     FieldFriendConfiguration,
     GnssConfiguration,
-    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     WheelsConfiguration,
@@ -32,5 +31,7 @@ config = FieldFriendConfiguration(
     circle_sight_positions=None,
     # TODO: height
     gnss=GnssConfiguration(x=0.0, y=0.778),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.5804, 0.00506, 0.0)),
+    # TODO: IMU configuration is probably wrong. Check https://github.com/zauberzeug/field_friend/pull/361
+    # imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.5804, 0.00506, 0.0)),
+    imu=None,
 )

--- a/config/f22.py
+++ b/config/f22.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose, Rotation
+from rosys.geometry import Rotation
 
 from field_friend.config.configuration import (
     FieldFriendConfiguration,
@@ -30,6 +30,7 @@ config = FieldFriendConfiguration(
     y_axis=None,
     z_axis=None,
     circle_sight_positions=None,
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.0, y=0.778, yaw=0.0)),
+    # TODO: height
+    gnss=GnssConfiguration(x=0.0, y=0.778),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.5804, 0.00506, 0.0)),
 )

--- a/config/u4.py
+++ b/config/u4.py
@@ -1,6 +1,4 @@
-# from rosys.geometry import Rotation
-
-from field_friend.config.configuration import (  # ImuConfiguration,
+from field_friend.config.configuration import (
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,

--- a/config/u4.py
+++ b/config/u4.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose, Rotation
+from rosys.geometry import Rotation
 
 from field_friend.config.configuration import (
     BumperConfiguration,
@@ -18,7 +18,8 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u4',
-    robot_brain=RobotBrainConfiguration(name='rb28', flash_params=['orin'], enable_esp_on_startup=True, use_espresso=True),
+    robot_brain=RobotBrainConfiguration(name='rb28', flash_params=[
+                                        'orin'], enable_esp_on_startup=True, use_espresso=True),
     tool='tornado',
     measurements=MeasurementsConfiguration(
         tooth_count=17,
@@ -89,6 +90,6 @@ config = FieldFriendConfiguration(
         turn_speed_limit=1.3,
         odrive_version=6,
     ),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.570796, 0, 0)),
 )

--- a/config/u4.py
+++ b/config/u4.py
@@ -1,6 +1,6 @@
-from rosys.geometry import Rotation
+# from rosys.geometry import Rotation
 
-from field_friend.config.configuration import (
+from field_friend.config.configuration import (  # ImuConfiguration,
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,
@@ -8,7 +8,6 @@ from field_friend.config.configuration import (
     FieldFriendConfiguration,
     FlashlightConfiguration,
     GnssConfiguration,
-    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     TornadoConfiguration,
@@ -91,5 +90,7 @@ config = FieldFriendConfiguration(
         odrive_version=6,
     ),
     gnss=GnssConfiguration(),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.570796, 0, 0)),
+    # TODO: IMU configuration is probably wrong. Check https://github.com/zauberzeug/field_friend/pull/361
+    # imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.570796, 0, 0)),
+    imu=None,
 )

--- a/config/u4.py
+++ b/config/u4.py
@@ -17,8 +17,10 @@ from field_friend.config.configuration import (  # ImuConfiguration,
 
 config = FieldFriendConfiguration(
     name='uckerbot-u4',
-    robot_brain=RobotBrainConfiguration(name='rb28', flash_params=[
-                                        'orin'], enable_esp_on_startup=True, use_espresso=True),
+    robot_brain=RobotBrainConfiguration(name='rb28',
+                                        flash_params=['orin'],
+                                        enable_esp_on_startup=True,
+                                        use_espresso=True),
     tool='tornado',
     measurements=MeasurementsConfiguration(
         tooth_count=17,

--- a/config/u5.py
+++ b/config/u5.py
@@ -1,6 +1,4 @@
-# from rosys.geometry import Rotation
-
-from field_friend.config.configuration import (  # ImuConfiguration,
+from field_friend.config.configuration import (
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,

--- a/config/u5.py
+++ b/config/u5.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose, Rotation
+from rosys.geometry import Rotation
 
 from field_friend.config.configuration import (
     BumperConfiguration,
@@ -18,7 +18,8 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u5',
-    robot_brain=RobotBrainConfiguration(name='rb33', flash_params=['orin', 'v05'], enable_esp_on_startup=True, use_espresso=True),
+    robot_brain=RobotBrainConfiguration(name='rb33', flash_params=[
+                                        'orin', 'v05'], enable_esp_on_startup=True, use_espresso=True),
     tool='weed_screw',
     measurements=MeasurementsConfiguration(
         tooth_count=17,
@@ -82,6 +83,6 @@ config = FieldFriendConfiguration(
         version='z_axis_canopen',
     ),
     circle_sight_positions=CircleSightPositions(),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.05165, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(x=0.05165),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6, 0.0261799, -0.0261799)),
 )

--- a/config/u5.py
+++ b/config/u5.py
@@ -1,6 +1,6 @@
-from rosys.geometry import Rotation
+# from rosys.geometry import Rotation
 
-from field_friend.config.configuration import (
+from field_friend.config.configuration import (  # ImuConfiguration,
     BumperConfiguration,
     CameraConfiguration,
     CircleSightPositions,
@@ -8,7 +8,6 @@ from field_friend.config.configuration import (
     FieldFriendConfiguration,
     FlashlightConfiguration,
     GnssConfiguration,
-    ImuConfiguration,
     MeasurementsConfiguration,
     RobotBrainConfiguration,
     WheelsConfiguration,
@@ -84,5 +83,7 @@ config = FieldFriendConfiguration(
     ),
     circle_sight_positions=CircleSightPositions(),
     gnss=GnssConfiguration(x=0.05165),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6, 0.0261799, -0.0261799)),
+    # TODO: IMU configuration is probably wrong. Check https://github.com/zauberzeug/field_friend/pull/361
+    # imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6, 0.0261799, -0.0261799)),
+    imu=None,
 )

--- a/config/u5.py
+++ b/config/u5.py
@@ -17,8 +17,10 @@ from field_friend.config.configuration import (  # ImuConfiguration,
 
 config = FieldFriendConfiguration(
     name='uckerbot-u5',
-    robot_brain=RobotBrainConfiguration(name='rb33', flash_params=[
-                                        'orin', 'v05'], enable_esp_on_startup=True, use_espresso=True),
+    robot_brain=RobotBrainConfiguration(name='rb33',
+                                        flash_params=['orin', 'v05'],
+                                        enable_esp_on_startup=True,
+                                        use_espresso=True),
     tool='weed_screw',
     measurements=MeasurementsConfiguration(
         tooth_count=17,

--- a/config/u6.py
+++ b/config/u6.py
@@ -1,4 +1,4 @@
-from rosys.geometry import Pose, Rotation
+from rosys.geometry import Rotation
 
 from field_friend.config.configuration import (
     BumperConfiguration,
@@ -17,7 +17,8 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u6',
-    robot_brain=RobotBrainConfiguration(name='rb34', flash_params=['orin', 'v05'], enable_esp_on_startup=True, use_espresso=True),
+    robot_brain=RobotBrainConfiguration(name='rb34', flash_params=[
+                                        'orin', 'v05'], enable_esp_on_startup=True, use_espresso=True),
     tool='weed_screw',
     measurements=MeasurementsConfiguration(tooth_count=17, pitch=0.041, work_x=0.085),
     camera=CameraConfiguration(
@@ -77,6 +78,6 @@ config = FieldFriendConfiguration(
         version='z_axis_canopen',
     ),
     circle_sight_positions=CircleSightPositions(),
-    gnss=GnssConfiguration(antenna_pose=Pose(x=0.041, y=-0.255, yaw=0.0)),
+    gnss=GnssConfiguration(),
     imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6006605, 0.0242387, 0.0)),
 )

--- a/config/u6.py
+++ b/config/u6.py
@@ -79,5 +79,5 @@ config = FieldFriendConfiguration(
     ),
     circle_sight_positions=CircleSightPositions(),
     gnss=GnssConfiguration(),
-    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.6006605, 0.0242387, 0.0)),
+    imu=ImuConfiguration(offset_rotation=Rotation.from_euler(-1.597158, 0.022681, 1.570198)),
 )

--- a/config/u6.py
+++ b/config/u6.py
@@ -17,8 +17,10 @@ from field_friend.config.configuration import (
 
 config = FieldFriendConfiguration(
     name='uckerbot-u6',
-    robot_brain=RobotBrainConfiguration(name='rb34', flash_params=[
-                                        'orin', 'v05'], enable_esp_on_startup=True, use_espresso=True),
+    robot_brain=RobotBrainConfiguration(name='rb34',
+                                        flash_params=['orin', 'v05'],
+                                        enable_esp_on_startup=True,
+                                        use_espresso=True),
     tool='weed_screw',
     measurements=MeasurementsConfiguration(tooth_count=17, pitch=0.041, work_x=0.085),
     camera=CameraConfiguration(

--- a/docs/tutorials/imu_calibration.md
+++ b/docs/tutorials/imu_calibration.md
@@ -1,9 +1,9 @@
 # Imu Calibration
 
-The IMU is not installed in it's intended orientation, that is why we have to find the correct values.
-The standard coordinate frame of our robots is a right handed one where X is forward, Y is left and Z is upward.
-The built-in IMUs orientation is X-left, Y-Down and Z-backward, therefore a roll rotation of -90° and a yaw rotation of 90° is needed for a robot brain in it's default configuration, where the socket connectors show backwards.
-Older Robots like U4 will need an additional yaw rotation of 90° afterwards, because their robot brains are built in sideways.
+The IMU is not installed in its intended orientation, that is why we have to find the correct values.
+The standard coordinate frame of our robots is a right-handed one where X is forward, Y is left and Z is upward.
+The built-in IMUs orientation is X-left, Y-down and Z-backward, therefore a roll rotation of -90° and a yaw rotation of 90° is needed for a Robot Brain in its default configuration, where the socket connectors show backwards.
+Older robots like U4 will need an additional yaw rotation of 90° afterwards, because their Robot Brains are built in sideways.
 
 Here is a short Python script to generate the needed configuration:
 
@@ -29,8 +29,11 @@ print(f'imu=Imu(offset_rotation=Rotation.from_euler({complete_correction.roll:.6
 
 Steps:
 
-1. Find the correct base orientation of your IMU. If your fieldfriend has the standard configuration, you can use this as a starting point:
+1. Find the correct base orientation of your IMU.
+   If your Field Friend has the standard configuration, you can use this as a starting point:
    `Imu(offset_rotation=Rotation.from_euler(-1.570796, -0.000000, 1.570796))`
 2. Roll and pitch your robot manually to check if the configuration is correct and the axes are correctly rotated.
 3. Place your robot on a level surface and check the IMU's current values on the [development page](http://192.168.42.2/dev)
-4. Put the shown values for roll and pitch in the script above. That will generate your final configuration values. Note, that IMU's values have some noise, so your configration won't be perfect.
+4. Put the shown values for roll and pitch in the script above.
+   That will generate your final configuration values.
+   Note, that IMU values have some noise, so your configuration won't be perfect.

--- a/docs/tutorials/imu_calibration.md
+++ b/docs/tutorials/imu_calibration.md
@@ -1,0 +1,36 @@
+# Imu Calibration
+
+The IMU is not installed in it's intended orientation, that is why we have to find the correct values.
+The standard coordinate frame of our robots is a right handed one where X is forward, Y is left and Z is upward.
+The built-in IMUs orientation is X-left, Y-Down and Z-backward, therefore a roll rotation of -90° and a yaw rotation of 90° is needed for a robot brain in it's default configuration, where the socket connectors show backwards.
+Older Robots like U4 will need an additional yaw rotation of 90° afterwards, because their robot brains are built in sideways.
+
+Here is a short Python script to generate the needed configuration:
+
+```python
+#!/usr/bin/env python3
+import numpy as np
+from rosys.geometry import Rotation
+
+base_rotation = Rotation.from_euler(np.deg2rad(-90), 0, np.deg2rad(90))
+print(f'{base_rotation=}')
+
+roll = np.deg2rad(0.0)
+pitch = np.deg2rad(0.0)
+correction = Rotation.from_euler(roll, pitch, 0.0)
+print(f'{correction=}')
+
+complete_correction = correction * base_rotation
+print(f'{complete_correction=}')
+
+print('\nCode snippet for your robot\'s configuration:')
+print(f'imu=Imu(offset_rotation=Rotation.from_euler({complete_correction.roll:.6f}, {complete_correction.pitch:.6f}, {complete_correction.yaw:.6f}))')
+```
+
+Steps:
+
+1. Find the correct base orientation of your IMU. If your fieldfriend has the standard configuration, you can use this as a starting point:
+   `Imu(offset_rotation=Rotation.from_euler(-1.570796, -0.000000, 1.570796))`
+2. Roll and pitch your robot manually to check if the configuration is correct and the axes are correctly rotated.
+3. Place your robot on a level surface and check the IMU's current values on the [development page](http://192.168.42.2/dev)
+4. Put the shown values for roll and pitch in the script above. That will generate your final configuration values. Note, that IMU's values have some noise, so your configration won't be perfect.

--- a/docs/tutorials/tutorials.md
+++ b/docs/tutorials/tutorials.md
@@ -4,3 +4,4 @@ Welcome to the Field Friend tutorials section! Here you'll find step-by-step gui
 
 - [Docker Management](docker_management.md) - Learn how to use the docker.sh script to manage your Field Friend containers
 - [Field Creation](field_creation.md) - Guide to creating and configuring fields for your robot
+- [IMU calibration](imu_calibration.md) - How determine the correct rotation for the ImuConfiguration

--- a/docs/tutorials/tutorials.md
+++ b/docs/tutorials/tutorials.md
@@ -4,4 +4,4 @@ Welcome to the Field Friend tutorials section! Here you'll find step-by-step gui
 
 - [Docker Management](docker_management.md) - Learn how to use the docker.sh script to manage your Field Friend containers
 - [Field Creation](field_creation.md) - Guide to creating and configuring fields for your robot
-- [IMU calibration](imu_calibration.md) - How determine the correct rotation for the ImuConfiguration
+- [IMU calibration](imu_calibration.md) - How to determine the correct rotation for the ImuConfiguration

--- a/field_friend/config/configuration.py
+++ b/field_friend/config/configuration.py
@@ -6,7 +6,7 @@ from rosys.geometry import Point3d, Pose, Rectangle, Rotation
 
 @dataclass(kw_only=True)
 class RobotBrainConfiguration:
-    """Configuration for the robot brain of the FieldFriend robot.
+    """Configuration for the robot brain of the Field Friend robot.
 
     Defaults:
         enable_esp_on_startup: None
@@ -19,7 +19,7 @@ class RobotBrainConfiguration:
 
 @dataclass(kw_only=True)
 class MeasurementsConfiguration:
-    """Configuration for the measurements of the FieldFriend robot.
+    """Configuration for the measurements of the Field Friend robot.
 
     Defaults:
         motor_gear_ratio: 12.52
@@ -45,7 +45,7 @@ class MeasurementsConfiguration:
 
 @dataclass(kw_only=True)
 class CropConfiguration:
-    """Configuration for the cropping of the camera of the FieldFriend robot."""
+    """Configuration for the cropping of the camera of the Field Friend robot."""
     left: int
     right: int
     up: int
@@ -70,7 +70,7 @@ class CircleSightPositions:
 
 @dataclass(kw_only=True)
 class CameraConfiguration:
-    """Configuration for the camera of the FieldFriend robot.
+    """Configuration for the camera of the Field Friend robot.
 
     Attributes:
         camera_type: default = 'CalibratableUsbCamera'
@@ -108,7 +108,7 @@ class CameraConfiguration:
 
 @dataclass(kw_only=True)
 class WheelsConfiguration:
-    """Configuration for the wheels of the FieldFriend robot.
+    """Configuration for the wheels of the Field Friend robot.
 
     Defaults:
         name: 'wheels'
@@ -129,7 +129,7 @@ class WheelsConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class CanConfiguration:
-    """Configuration for the can of the FieldFriend robot.
+    """Configuration for the can of the Field Friend robot.
 
     Defaults:
         name: 'can'
@@ -147,7 +147,7 @@ class CanConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class BumperConfiguration:
-    """Configuration for the bumper of the FieldFriend robot.
+    """Configuration for the bumper of the Field Friend robot.
 
     Defaults:
         name: 'bumper'
@@ -170,7 +170,7 @@ class BumperConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class BatteryControlConfiguration:
-    """Configuration for the battery control of the FieldFriend robot.
+    """Configuration for the battery control of the Field Friend robot.
 
     Defaults:
         name: 'battery_control'
@@ -186,7 +186,7 @@ class BatteryControlConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class BmsConfiguration:
-    """Configuration for the bms of the FieldFriend robot.
+    """Configuration for the bms of the Field Friend robot.
 
     Defaults:
         name: 'bms'
@@ -206,7 +206,7 @@ class BmsConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class EstopConfiguration:
-    """Configuration for the estop of the FieldFriend robot.
+    """Configuration for the estop of the Field Friend robot.
 
     Defaults:
         name: 'estop'
@@ -227,7 +227,7 @@ class EstopConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class FlashlightConfiguration:
-    """Configuration for the flashlight of the FieldFriend robot.
+    """Configuration for the flashlight of the Field Friend robot.
 
     Attributes:
         name: default = 'flashlight'
@@ -251,10 +251,11 @@ class FlashlightConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class GnssConfiguration:
-    """Configuration for the gnss of the FieldFriend robot.
+    """Configuration for the GNSS of the Field Friend robot.
 
-    X, Y, Z are the position of the main gnss antenna.
-    The yaw is the direction to the auxiliary antenna. It should be 90°, but the offset is configured in the septentrio software.
+    X, Y, Z are the position of the main GNSS antenna.
+    The yaw is the direction to the auxiliary antenna.
+    It should be 90°, but the offset is configured in the Septentrio software.
 
     Defaults:
         x: 0.041
@@ -278,7 +279,7 @@ class GnssConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class ImuConfiguration:
-    """Configuration for the IMU of the FieldFriend robot.
+    """Configuration for the IMU of the Field Friend robot.
 
     Defaults:
         name: 'imu'
@@ -470,7 +471,7 @@ class SprayerConfiguration:
 
 @dataclass(slots=True, kw_only=True)
 class FieldFriendConfiguration:
-    """Configuration for the FieldFriend robot.
+    """Configuration for the Field Friend robot.
 
     Defaults:
         can: CanConfiguration

--- a/field_friend/config/configuration.py
+++ b/field_friend/config/configuration.py
@@ -253,6 +253,7 @@ class FlashlightConfiguration:
 class GnssConfiguration:
     """Configuration for the gnss of the FieldFriend robot.
 
+    X, Y, Z are the position of the main gnss antenna.
     The yaw is the direction to the auxiliary antenna. It should be 90°, but the offset is configured in the septentrio software.
 
     Defaults:

--- a/field_friend/config/configuration.py
+++ b/field_friend/config/configuration.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from rosys.geometry import Pose, Rectangle, Rotation
+from rosys.geometry import Point3d, Pose, Rectangle, Rotation
 
 
 @dataclass(kw_only=True)
@@ -253,12 +253,26 @@ class FlashlightConfiguration:
 class GnssConfiguration:
     """Configuration for the gnss of the FieldFriend robot.
 
-    The yaw should be 90°, but the offset is configured in the septentrio software.
+    The yaw is the direction to the auxiliary antenna. It should be 90°, but the offset is configured in the septentrio software.
 
     Defaults:
-        antenna_pose: Pose(x=0.041, y=-0.255, yaw=0.0)
+        x: 0.041
+        y: -0.255
+        z: 0.6225
+        yaw: 0.0
     """
-    antenna_pose: Pose = field(default_factory=lambda: Pose(x=0.041, y=-0.255, yaw=0.0))
+    x: float = 0.041
+    y: float = -0.255
+    z: float = 0.6225
+    yaw: float = 0.0
+
+    @property
+    def pose(self) -> Pose:
+        return Pose(x=self.x, y=self.y, yaw=self.yaw)
+
+    @property
+    def point3d(self) -> Point3d:
+        return Point3d(x=self.x, y=self.y, z=self.z)
 
 
 @dataclass(slots=True, kw_only=True)

--- a/field_friend/robot_locator.py
+++ b/field_friend/robot_locator.py
@@ -6,7 +6,7 @@ import rosys
 import rosys.helpers
 from nicegui import ui
 from rosys.geometry import Pose, Pose3d, Rotation, Velocity
-from rosys.hardware import Gnss, GnssMeasurement, Imu, ImuHardware, ImuMeasurement, Wheels, WheelsSimulation
+from rosys.hardware import Gnss, GnssMeasurement, Imu, ImuMeasurement, Wheels, WheelsSimulation
 
 from .config.configuration import GnssConfiguration
 
@@ -36,10 +36,9 @@ class RobotLocator(rosys.persistence.Persistable):
         # NOTE: the prediction step needs to be run once before the first GNSS update
         self._first_prediction_done = False
 
-        # bound attributes
         self._ignore_gnss = gnss is None
         self._ignore_imu = imu is None
-        self._use_height_correction = not self._ignore_imu and isinstance(imu, ImuHardware)
+        self._use_height_correction = isinstance(imu, Imu) and not self._ignore_imu
         self._r_odom_linear = self.R_ODOM_LINEAR
         self._r_odom_angular = self.R_ODOM_ANGULAR
         self._r_imu_angular = self.R_IMU_ANGULAR

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -271,8 +271,7 @@ class System(rosys.persistence.Persistable):
                                                                             pitch=np.deg2rad(0),
                                                                             yaw=np.deg2rad(90),
                                                                             color='#cccccc',
-                                                                            frame=self.robot_locator.pose_frame,
-                                                                            )
+                                                                            frame=self.robot_locator.pose_frame)
         assert isinstance(self.camera_provider, rosys.vision.SimulatedCameraProvider)
         self.camera_provider.add_camera(camera)
 
@@ -287,7 +286,7 @@ class System(rosys.persistence.Persistable):
         if self.config.gnss is None:
             return None
         if self.is_real:
-            gnss_hardware = GnssHardware(antenna_pose=self.config.gnss.antenna_pose)
+            gnss_hardware = GnssHardware(antenna_pose=self.config.gnss.pose)
             gnss_hardware.MAX_TIMESTAMP_DIFF = 0.25
             return gnss_hardware
         assert isinstance(wheels, rosys.hardware.WheelsSimulation)

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -67,7 +67,10 @@ class System(rosys.persistence.Persistable):
                 self.log.exception(f'failed to initialize FieldFriendHardware {self.robot_id}')
             assert isinstance(self.field_friend, FieldFriendHardware)
             self.gnss = self.setup_gnss()
-            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent()
+            self.robot_locator = RobotLocator(self.field_friend.wheels,
+                                              self.gnss,
+                                              self.field_friend.imu,
+                                              gnss_height=self.config.gnss.z if self.config.gnss is not None else 0.0).persistent()
             self.mjpeg_camera_provider = rosys.vision.MjpegCameraProvider(username='root', password='zauberzg!')
             self.detector = rosys.vision.DetectorHardware(port=8004)
             self.circle_sight_detector = rosys.vision.DetectorHardware(port=8005)

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -68,9 +68,9 @@ class System(rosys.persistence.Persistable):
             assert isinstance(self.field_friend, FieldFriendHardware)
             self.gnss = self.setup_gnss()
             self.robot_locator = RobotLocator(self.field_friend.wheels,
-                                              self.gnss,
-                                              self.field_friend.imu,
-                                              gnss_height=self.config.gnss.z if self.config.gnss is not None else 0.0).persistent()
+                                              gnss=self.gnss,
+                                              imu=self.field_friend.imu,
+                                              gnss_config=self.config.gnss).persistent()
             self.mjpeg_camera_provider = rosys.vision.MjpegCameraProvider(username='root', password='zauberzg!')
             self.detector = rosys.vision.DetectorHardware(port=8004)
             self.circle_sight_detector = rosys.vision.DetectorHardware(port=8005)
@@ -78,7 +78,10 @@ class System(rosys.persistence.Persistable):
             self.field_friend = FieldFriendSimulation(self.config, use_acceleration=use_acceleration)
             assert isinstance(self.field_friend.wheels, rosys.hardware.WheelsSimulation)
             self.gnss = self.setup_gnss(self.field_friend.wheels)
-            self.robot_locator = RobotLocator(self.field_friend.wheels, self.gnss, self.field_friend.imu).persistent()
+            self.robot_locator = RobotLocator(self.field_friend.wheels,
+                                              gnss=self.gnss,
+                                              imu=self.field_friend.imu,
+                                              gnss_config=self.config.gnss).persistent()
             # NOTE we run this in rosys.startup to enforce setup AFTER the persistence is loaded
             rosys.on_startup(self.setup_simulated_usb_camera)
             if self.camera_provider is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fiona
 geopandas
 geopy
-git+https://github.com/zauberzeug/rosys.git@imu_simulation_expansion
+git+https://github.com/zauberzeug/rosys.git@81cff326d6a66ddf55ba3bc764cfda8c713c720f
 icecream
 pillow
 prompt-toolkit # for lizard monitor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 fiona
 geopandas
 geopy
+git+https://github.com/zauberzeug/rosys.git@imu_simulation_expansion
 icecream
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2
-rosys == 0.28.0
 shapely
 uvicorn == 0.28.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator, Generator
 import pytest
 import rosys
 from rosys.geometry import GeoPoint, GeoReference, Pose
-from rosys.hardware import GnssSimulation, WheelsSimulation
+from rosys.hardware import GnssSimulation, ImuSimulation, WheelsSimulation
 from rosys.testing import forward, helpers
 
 from field_friend.automations import Field, Row
@@ -77,6 +77,12 @@ async def system_with_acceleration(rosys_integration) -> AsyncGenerator[System, 
 def gnss(system: System) -> GnssSimulation:
     assert isinstance(system.gnss, GnssSimulation)
     return system.gnss
+
+
+@pytest.fixture
+def imu(system: System) -> ImuSimulation:
+    assert isinstance(system.field_friend.imu, ImuSimulation)
+    return system.field_friend.imu
 
 
 class TestField:

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -1,6 +1,9 @@
+import numpy as np
+import pytest
 import rosys
 from conftest import ROBOT_GEO_START_POSITION
-from rosys.hardware.gnss import GnssSimulation, GpsQuality
+from rosys.geometry import Pose
+from rosys.hardware import GnssSimulation, GpsQuality, ImuSimulation
 from rosys.testing import assert_point, forward
 
 from field_friend.system import System
@@ -8,6 +11,7 @@ from field_friend.system import System
 
 async def test_driving(gnss_driving: System):
     assert_point(gnss_driving.robot_locator.pose.point, rosys.geometry.Point(x=0, y=0))
+    assert gnss_driving.gnss is not None
     assert gnss_driving.gnss.last_measurement is not None
     assert gnss_driving.gnss.last_measurement.point.distance(ROBOT_GEO_START_POSITION) < 0.01
     await forward(x=2.0)
@@ -49,3 +53,14 @@ async def test_rtk_lost(gnss_driving: System, gnss: GnssSimulation):
     await forward(5)
     # robot should continue driving
     assert gnss_driving.robot_locator.pose.point.x > 2.5
+
+
+@pytest.mark.parametrize('direction', (-1, 1))
+async def test_height_correction(system: System, imu: ImuSimulation, direction: int):
+    # pylint: disable=protected-access
+    imu.roll = np.deg2rad(10.0) * direction
+    imu.pitch = np.deg2rad(10.0) * direction
+    await forward(1)
+    corrected_pose = system.robot_locator._correct_gnss_with_imu(Pose(x=0.0, y=0.0, yaw=0.0))
+    assert corrected_pose.x == pytest.approx(direction * -0.108, abs=0.01)
+    assert corrected_pose.y == pytest.approx(direction * 0.112, abs=0.01)

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -3,7 +3,8 @@ import pytest
 import rosys
 from conftest import ROBOT_GEO_START_POSITION
 from rosys.geometry import Pose
-from rosys.hardware import GnssSimulation, GpsQuality, ImuSimulation
+from rosys.hardware import GnssSimulation, ImuSimulation
+from rosys.hardware.gnss import GpsQuality
 from rosys.testing import assert_point, forward
 
 from field_friend.system import System

--- a/tests/test_gnss.py
+++ b/tests/test_gnss.py
@@ -56,12 +56,13 @@ async def test_rtk_lost(gnss_driving: System, gnss: GnssSimulation):
     assert gnss_driving.robot_locator.pose.point.x > 2.5
 
 
-@pytest.mark.parametrize('direction', (-1, 1))
-async def test_height_correction(system: System, imu: ImuSimulation, direction: int):
+@pytest.mark.parametrize('roll_direction', (-1, 1))
+@pytest.mark.parametrize('pitch_direction', (-1, 1))
+async def test_height_correction(system: System, imu: ImuSimulation, roll_direction: int, pitch_direction: int):
     # pylint: disable=protected-access
-    imu.roll = np.deg2rad(10.0) * direction
-    imu.pitch = np.deg2rad(10.0) * direction
+    imu.roll = np.deg2rad(10.0) * roll_direction
+    imu.pitch = np.deg2rad(10.0) * pitch_direction
     await forward(1)
     corrected_pose = system.robot_locator._correct_gnss_with_imu(Pose(x=0.0, y=0.0, yaw=0.0))
-    assert corrected_pose.x == pytest.approx(direction * -0.108, abs=0.01)
-    assert corrected_pose.y == pytest.approx(direction * 0.112, abs=0.01)
+    assert corrected_pose.x == pytest.approx(pitch_direction * -0.108, abs=0.01)
+    assert corrected_pose.y == pytest.approx(roll_direction * 0.112, abs=0.01)


### PR DESCRIPTION
### Motivation & Implementation

Since our GNSS antennas are on the top of the robot, the position will be wrong when the robot is tilted.
@Johannes-Thiel already started to implement this in https://github.com/zauberzeug/field_friend/pull/232 (with a useful diagram), but I think this implementation is more sleek.

⚠️ Breaking change: Due to a misunderstanding the IMU configuration of other robots are probably wrong. So I will remove all configurations and add documentation on how to configure it.


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
    - [x] Handle height correction 
    - [x] Is the [calculation of the GNSS center position](https://github.com/zauberzeug/rosys/blob/d2fa3311fcb0a42ee195f4c0671bf60f7133ce0a/rosys/hardware/gnss.py#L224-L225) affected by the attitude?
    - [x] Remove warning logs
    - [x] Remove IMU calibrations of other robots
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
    - [x] Wait for https://github.com/zauberzeug/rosys/pull/318 
- [x] Documentation has been added (or is not necessary).
    - [x] Add How To for the IMU configuration
