### PR TITLE
Add a GNSS heading check to the AutomationWatcher

### DIFF
--- a/field_friend/automations/automation_watcher.py
+++ b/field_friend/automations/automation_watcher.py
@@ -4,6 +4,7 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
+import numpy as np
 import rosys
 from rosys.geometry import GeoPoint, Pose
 from rosys.hardware.gnss import GpsQuality
@@ -107,7 +108,8 @@ class AutomationWatcher:
         return self.gnss.is_connected \
             and self.gnss.last_measurement is not None \
             and rosys.time() - self.gnss.last_measurement.time < 2.0 \
-            and self.gnss.last_measurement.gps_quality == GpsQuality.RTK_FIXED
+            and self.gnss.last_measurement.gps_quality == GpsQuality.RTK_FIXED \
+            and np.isfinite(self.gnss.last_measurement.heading_std_dev)
 
     def try_resume(self) -> None:
         # Set conditions to True by default, which means they don't block the process if the watch is not active


### PR DESCRIPTION
### Motivation && Implementation

I noticed that the robot drove of the path despite receiving RTK corrections.
GNSS messages can have the RTK_FIXED quality and still have no heading data. We cannot safely navigate without it.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [ ] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
