### PR TITLE
Fix status API when ESP is not ready

### DIFF
--- a/field_friend/api/status.py
+++ b/field_friend/api/status.py
@@ -25,11 +25,15 @@ class Status:
                 'paused' if self.system.automator.automation is not None and self.system.automator.automation.is_paused else \
                 'idle'
             if self.system.is_real:
-                lizard_firmware = cast(FieldFriendHardware, self.system.field_friend).robot_brain.lizard_firmware
-                await lizard_firmware.read_core_version()
-                await lizard_firmware.read_p0_version()
-                core_version = lizard_firmware.core_version
-                p0_version = lizard_firmware.p0_version
+                try:
+                    lizard_firmware = cast(FieldFriendHardware, self.system.field_friend).robot_brain.lizard_firmware
+                    await lizard_firmware.read_core_version()
+                    await lizard_firmware.read_p0_version()
+                    core_version = lizard_firmware.core_version
+                    p0_version = lizard_firmware.p0_version
+                except rosys.hardware.robot_brain.EspNotReadyException:
+                    core_version = 'unknown'
+                    p0_version = 'unknown'
             else:
                 core_version = 'simulation'
                 p0_version = 'simulation'


### PR DESCRIPTION
### Motivation & Implementation

The lizard versions can't be read from the ESP when it is not ready yet. This PR handles the `EspNotReadyException`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
