### PR TITLE
Limit the Recorder's capture interval

### DIFF
--- a/field_friend/automations/implements/recorder.py
+++ b/field_friend/automations/implements/recorder.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import rosys
+from nicegui import ui
 
 from .weeding_implement import Implement
 
@@ -13,10 +14,12 @@ if TYPE_CHECKING:
 
 
 class Recorder(Implement):
+    RECORDING_INTERVAL = 1.0
 
     def __init__(self, system: System) -> None:
         super().__init__('Recorder')
         self.system = system
+        self.recording_interval = self.RECORDING_INTERVAL
 
     async def prepare(self) -> bool:
         await super().prepare()
@@ -30,11 +33,30 @@ class Recorder(Implement):
         if self.system.field_friend.flashlight:
             await self.system.field_friend.flashlight.turn_on()
         await rosys.sleep(3)  # NOTE: we wait for the camera to adjust
+        self.system.plant_locator.interval = self.recording_interval
         self.system.plant_locator.resume()
         await super().activate()
 
     async def deactivate(self):
         self.system.plant_locator.pause()
+        self.system.plant_locator.interval = self.system.plant_locator.INTERVAL
         if self.system.field_friend.flashlight:
             await self.system.field_friend.flashlight.turn_off()
         await super().deactivate()
+
+    def backup_to_dict(self) -> dict[str, Any]:
+        return super().backup_to_dict() | {
+            'recording_interval': self.recording_interval,
+        }
+
+    def restore_from_dict(self, data: dict[str, Any]) -> None:
+        super().restore_from_dict(data)
+        self.recording_interval = data.get('recording_interval', self.recording_interval)
+
+    def settings_ui(self):
+        super().settings_ui()
+        ui.number('Recording interval', step=0.01, min=0.01, format='%.2f', on_change=self.request_backup) \
+            .props('dense outlined suffix=s') \
+            .classes('w-28') \
+            .bind_value(self, 'recording_interval') \
+            .tooltip(f'Set the interval between image captures (default: {self.RECORDING_INTERVAL:.2f}s)')

--- a/field_friend/automations/navigation/field_navigation.py
+++ b/field_friend/automations/navigation/field_navigation.py
@@ -47,8 +47,6 @@ class FieldNavigation(WaypointNavigation):
         self.charge_automatically = self.CHARGE_AUTOMATICALLY
         self.force_charge = False
 
-        self.SEGMENT_STARTED.register(self._handle_segment_started)
-
     @property
     def field(self) -> Field | None:
         return self.field_provider.selected_field
@@ -58,6 +56,7 @@ class FieldNavigation(WaypointNavigation):
         return self.current_segment.row if isinstance(self.current_segment, RowSegment) else None
 
     def _handle_segment_started(self, segment: DriveSegment) -> None:
+        super()._handle_segment_started(segment)
         if isinstance(segment, RowSegment) and isinstance(self.implement, WeedingImplement):
             self.log.debug(f'Setting crop to {segment.row.crop}')
             self.implement.cultivated_crop = segment.row.crop

--- a/field_friend/interface/components/robot_scene.py
+++ b/field_friend/interface/components/robot_scene.py
@@ -24,14 +24,14 @@ class RobotScene:
         self.scene_look = False
         self.locked_view = True
 
-        with self.scene_card.tight().classes('w-full place-items-center').style('max-width: 100%; overflow: hidden;'):
+        with self.scene_card.tight().classes('w-full h-full place-items-center').style('max-width: 100%; max-height: 40%;'):
             def toggle_lock():
                 self.locked_view = not self.locked_view
                 self.lock_view_button.props(f'flat color={"primary" if self.locked_view else "grey"}')
             self.lock_view_button = ui.button(icon='sym_o_visibility_lock', on_click=toggle_lock).props('flat color=primary') \
                 .style('position: absolute; left: 1px; top: 1px; z-index: 500;').tooltip('Lock view to robot')
 
-            with ui.scene(200, 200, on_click=self.handle_click, grid=True).classes('w-full') as self.scene:
+            with ui.scene(200, 200, on_click=self.handle_click, grid=True).classes('w-full h-full') as self.scene:
                 field_friend_object(self.system.robot_locator, self.system.camera_provider,
                                     self.system.field_friend, width=self.system.config.measurements.wheel_distance)
                 rosys.driving.driver_object(self.system.driver)

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -89,6 +89,9 @@ class System(rosys.persistence.Persistable):
         self.odometer = Odometer(self.field_friend.wheels)
         self.setup_driver()
         self.plant_provider = PlantProvider().persistent()
+        self.plant_locator: PlantLocator = PlantLocator(self).persistent()
+        self.puncher: Puncher = Puncher(self.field_friend, self.driver)
+
         self.kpi_provider = KpiProvider().persistent()
         if not self.is_real:
             generate_kpis(self.kpi_provider)
@@ -98,10 +101,6 @@ class System(rosys.persistence.Persistable):
                 self.kpi_provider.increment_on_rising_edge('bumps', bool(self.field_friend.bumper.active_bumpers))
             if self.field_friend.bms:
                 self.kpi_provider.increment_on_rising_edge('low_battery', self.field_friend.bms.is_below_percent(10.0))
-
-        self.puncher: Puncher = Puncher(self.field_friend, self.driver)
-        self.plant_locator: PlantLocator = PlantLocator(self).persistent()
-
         rosys.on_repeat(watch_robot, 1.0)
 
         self.field_provider: FieldProvider = FieldProvider().persistent()

--- a/field_friend/system.py
+++ b/field_friend/system.py
@@ -88,6 +88,11 @@ class System(rosys.persistence.Persistable):
                                                           camera_config=self.config.camera)
         self.odometer = Odometer(self.field_friend.wheels)
         self.setup_driver()
+        self.automator: rosys.automation.Automator = rosys.automation.Automator(
+            self.steerer,
+            on_interrupt=self.field_friend.stop,
+            notify=False,
+        )
         self.plant_provider = PlantProvider().persistent()
         self.plant_locator: PlantLocator = PlantLocator(self).persistent()
         self.puncher: Puncher = Puncher(self.field_friend, self.driver)
@@ -104,11 +109,6 @@ class System(rosys.persistence.Persistable):
         rosys.on_repeat(watch_robot, 1.0)
 
         self.field_provider: FieldProvider = FieldProvider().persistent()
-        self.automator: rosys.automation.Automator = rosys.automation.Automator(
-            self.steerer,
-            on_interrupt=self.field_friend.stop,
-            notify=False,
-        )
         self.automation_watcher: AutomationWatcher = AutomationWatcher(self)
 
         self.setup_timelapse()


### PR DESCRIPTION
### Motivation & Implementation

The Recorder implement will record a lot of images that are not really needed for the first trainings. That is why you can now set the recording interval in the implement settings menu. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
