### PR TITLE
Use RobotLocator's position on LeafletMap

### DIFF
--- a/field_friend/interface/components/leaflet_map.py
+++ b/field_friend/interface/components/leaflet_map.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from nicegui import app, ui
 from nicegui.elements.leaflet_layers import GenericLayer, Marker, TileLayer
 from rosys.geometry import GeoPoint
-from rosys.hardware import GnssMeasurement
 
 if TYPE_CHECKING:
     from ...system import System
@@ -50,9 +49,7 @@ class LeafletMap:
         self.field_provider.FIELDS_CHANGED.register_ui(self.update_layers)
         self.field_provider.FIELD_SELECTED.register_ui(self.update_layers)
         self.system.GNSS_REFERENCE_CHANGED.register_ui(self.update_layers)
-
-        if self.gnss is not None:
-            self.gnss.NEW_MEASUREMENT.register_ui(self.update_robot_position)
+        ui.timer(5, self.update_robot_position)
 
     def buttons(self) -> None:
         """Builds additional buttons to interact with the map."""
@@ -90,7 +87,7 @@ class LeafletMap:
                 row_points = [p.degree_tuple for p in row.points]
                 self.row_layers.append(self.m.generic_layer(name='polyline', args=[row_points, {'color': '#F2C037'}]))
 
-    def update_robot_position(self, _: GnssMeasurement, dialog=None) -> None:
+    def update_robot_position(self, dialog=None) -> None:
         # TODO: where does the dialog come from?
         if dialog:
             self.on_dialog_close()


### PR DESCRIPTION
### Motivation & Implementation

The LeafletMap was using the GNSS measurement position directly, which caused a jumpy icon position but more importantly made it hard to detect problems with the Kalman Filter or the GNSS reference.

I also reduced the map update interval to a 5 second timer. Because the GNSS event comes in every 0.1 seconds, which is not necessary.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
