### PR TITLE
Add button to the app to toggle the software estop

### DIFF
--- a/field_friend/app_controls.py
+++ b/field_friend/app_controls.py
@@ -26,6 +26,8 @@ class AppControls(RosysAppControls):
         self.last_bumpers_active: list[str] = []
         self.last_info: str = ''
         self.APP_CONNECTED.register(self.reset)
+        if self.field_friend.estop:
+            self.extra_buttons['estop'] = AppButton('warning', released=self._toggle_estop)
         if self.capture:
             self.extra_buttons['front'] = \
                 AppButton('file_upload', released=self.capture.front)
@@ -67,3 +69,6 @@ class AppControls(RosysAppControls):
 
     def reset(self) -> None:
         self.last_info = 'loading'
+
+    async def _toggle_estop(self):
+        await self.field_friend.estop.set_soft_estop(not self.field_friend.estop.is_soft_estop_active)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ geopandas
 geopy
 git+https://github.com/zauberzeug/rosys.git@76f82eb0af1a61a6fb94d1f975b5e7b7a3b40d32
 icecream
+nicegui == 2.24.2
 pillow
 prompt-toolkit # for lizard monitor
 pynmea2


### PR DESCRIPTION
### Motivation & Implementation

There was no way to disable the software estop without access to the web interface of the robot.
Now there is an additional button with a warning icon to toggle the software estop.


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
