### PR TITLE
Check velocity readings for validity

### DIFF
--- a/field_friend/hardware/double_wheels.py
+++ b/field_friend/hardware/double_wheels.py
@@ -7,6 +7,7 @@ from ..config import WheelsConfiguration
 class DoubleWheelsHardware(rosys.hardware.Wheels, rosys.hardware.ModuleHardware):
     """Expands the RoSys wheels hardware to control the field friend's tracked wheels with dual motors."""
     MAX_VALID_LINEAR_VELOCITY = 2.0
+    MAX_VALID_ANGULAR_VELOCITY = 3.5
 
     def __init__(self, config: WheelsConfiguration, robot_brain: rosys.hardware.RobotBrain, estop: rosys.hardware.EStopHardware, *,
                  can: rosys.hardware.CanHardware,
@@ -71,7 +72,7 @@ class DoubleWheelsHardware(rosys.hardware.Wheels, rosys.hardware.ModuleHardware)
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
         velocity = rosys.geometry.Velocity(linear=float(words.pop(0)), angular=float(words.pop(0)), time=time)
-        if abs(velocity.linear) <= self.MAX_VALID_LINEAR_VELOCITY:
+        if abs(velocity.linear) <= self.MAX_VALID_LINEAR_VELOCITY and abs(velocity.angular) <= self.MAX_VALID_ANGULAR_VELOCITY:
             self.VELOCITY_MEASURED.emit([velocity])
         else:
             self.log.error('Velocity is too high: (%s, %s)', velocity.linear, velocity.angular)

--- a/field_friend/hardware/double_wheels.py
+++ b/field_friend/hardware/double_wheels.py
@@ -6,6 +6,7 @@ from ..config import WheelsConfiguration
 
 class DoubleWheelsHardware(rosys.hardware.Wheels, rosys.hardware.ModuleHardware):
     """Expands the RoSys wheels hardware to control the field friend's tracked wheels with dual motors."""
+    MAX_VALID_LINEAR_VELOCITY = 2.0
 
     def __init__(self, config: WheelsConfiguration, robot_brain: rosys.hardware.RobotBrain, estop: rosys.hardware.EStopHardware, *,
                  can: rosys.hardware.CanHardware,
@@ -70,7 +71,11 @@ class DoubleWheelsHardware(rosys.hardware.Wheels, rosys.hardware.ModuleHardware)
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
         velocity = rosys.geometry.Velocity(linear=float(words.pop(0)), angular=float(words.pop(0)), time=time)
-        self.VELOCITY_MEASURED.emit([velocity])
+        if abs(velocity.linear) <= self.MAX_VALID_LINEAR_VELOCITY:
+            self.VELOCITY_MEASURED.emit([velocity])
+        else:
+            self.log.error('Velocity is too high: (%s, %s)', velocity.linear, velocity.angular)
+
         if self.config.odrive_version == 6:
             self.motor_error = any([self.l0_error, self.r0_error, self.l1_error, self.r1_error])
             self.l0_error = int(words.pop(0))

--- a/field_friend/hardware/double_wheels.py
+++ b/field_friend/hardware/double_wheels.py
@@ -6,7 +6,7 @@ from ..config import WheelsConfiguration
 
 class DoubleWheelsHardware(rosys.hardware.Wheels, rosys.hardware.ModuleHardware):
     """Expands the RoSys wheels hardware to control the field friend's tracked wheels with dual motors."""
-    MAX_VALID_LINEAR_VELOCITY = 2.0
+    MAX_VALID_LINEAR_VELOCITY = 3.0
     MAX_VALID_ANGULAR_VELOCITY = 3.5
 
     def __init__(self, config: WheelsConfiguration, robot_brain: rosys.hardware.RobotBrain, estop: rosys.hardware.EStopHardware, *,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fiona
 geopandas
 geopy
-git+https://github.com/zauberzeug/rosys.git@76f82eb0af1a61a6fb94d1f975b5e7b7a3b40d32
+git+https://github.com/zauberzeug/rosys.git@80819516bf5c124581a8f4772e039dd2cf1057b8
 icecream
 pillow
 prompt-toolkit # for lizard monitor


### PR DESCRIPTION
### Motivation & Implementation

We had Issue where the ODrive motor controllers delivered a far too high velocity reading.
https://github.com/zauberzeug/lizard/pull/160
This PR adds a safeguard to skip those measurements.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
    - [x] Implement `MAX_VALID_ANGULAR_VELOCITY`
    - [x] Wait for https://github.com/zauberzeug/rosys/pull/344 
- [x] Tests with a real hardware have been successful (or are not necessary).
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
